### PR TITLE
feat: add touying-reducer for cetz and fletcher animation

### DIFF
--- a/examples/example.typ
+++ b/examples/example.typ
@@ -107,7 +107,7 @@
 
 // fletcher animation
 #slide[
-  Cetz in Touying:
+  Fletcher in Touying:
 
   #fletcher-diagram(
     node-stroke: .1em,

--- a/examples/example.typ
+++ b/examples/example.typ
@@ -1,4 +1,9 @@
-#import "../lib.typ": s, pause, meanwhile, touying-equation, utils, states, pdfpc, themes
+#import "../lib.typ": s, pause, meanwhile, touying-equation, touying-reducer, utils, states, pdfpc, themes
+#import "@preview/cetz:0.2.0"
+#import "@preview/fletcher:0.4.1" as fletcher: node, edge
+
+#let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide)
+#let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
 // You can comment out the theme registration below and it can still work normally
 #let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
@@ -77,6 +82,48 @@
   #meanwhile
 
   Touying equation is very simple.
+]
+
+// cetz animation
+#slide[
+  Cetz in Touying:
+
+  #cetz-canvas({
+    import cetz.draw: *
+    
+    rect((0,0), (5,5))
+
+    (pause,)
+
+    rect((0,0), (1,1))
+    rect((1,1), (2,2))
+    rect((2,2), (3,3))
+
+    (pause,)
+
+    line((0,0), (2.5, 2.5), name: "line")
+  })
+]
+
+// fletcher animation
+#slide[
+  Cetz in Touying:
+
+  #fletcher-diagram(
+    node-stroke: .1em,
+    node-fill: gradient.radial(blue.lighten(80%), blue, center: (30%, 20%), radius: 80%),
+    spacing: 4em,
+    edge((-1,0), "r", "-|>", `open(path)`, label-pos: 0, label-side: center),
+    node((0,0), `reading`, radius: 2em),
+    edge((0,0), (0,0), `read()`, "--|>", bend: 130deg),
+    pause,
+    edge(`read()`, "-|>"),
+    node((1,0), `eof`, radius: 2em),
+    pause,
+    edge(`close()`, "-|>"),
+    node((2,0), `closed`, radius: 2em, extrude: (-2.5, 0)),
+    edge((0,0), (2,0), `close()`, "-|>", bend: -40deg),
+  )
 ]
 
 // multiple pages for one slide

--- a/lib.typ
+++ b/lib.typ
@@ -1,4 +1,4 @@
-#import "slide.typ": s, pause, meanwhile, slides-end, touying-equation
+#import "slide.typ": s, pause, meanwhile, slides-end, touying-equation, touying-reducer
 #import "utils/utils.typ"
 #import "utils/states.typ"
 #import "utils/pdfpc.typ"


### PR DESCRIPTION
This is the `touying-reducer` function that Touying is planning to add. It allows decoupling Touying from specific packages dependencies, while still enabling easy support for `pause` and `meanwhile` animations for Cetz and Fletcher. Any suggestions on Touying's interface are welcome :-) @johannes-wolf @Jollywatt @fenjalien 

```typst
#import "../lib.typ": *
#import "@preview/cetz:0.2.0"
#import "@preview/fletcher:0.4.1" as fletcher: node, edge

#let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide)
#let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))

#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
#let (init, slide) = utils.methods(s)
#show: init

// cetz animation
#slide[
  Cetz in Touying:

  #cetz-canvas({
    import cetz.draw: *
    
    rect((0,0), (5,5))

    (pause,)

    rect((0,0), (1,1))
    rect((1,1), (2,2))
    rect((2,2), (3,3))

    (pause,)

    line((0,0), (2.5, 2.5), name: "line")
  })
]

// fletcher animation
#slide[
  Fletcher in Touying:

  #fletcher-diagram(
    node-stroke: .1em,
    node-fill: gradient.radial(blue.lighten(80%), blue, center: (30%, 20%), radius: 80%),
    spacing: 4em,
    edge((-1,0), "r", "-|>", `open(path)`, label-pos: 0, label-side: center),
    node((0,0), `reading`, radius: 2em),
    edge((0,0), (0,0), `read()`, "--|>", bend: 130deg),
    pause,
    edge(`read()`, "-|>"),
    node((1,0), `eof`, radius: 2em),
    pause,
    edge(`close()`, "-|>"),
    node((2,0), `closed`, radius: 2em, extrude: (-2.5, 0)),
    edge((0,0), (2,0), `close()`, "-|>", bend: -40deg),
  )
]
```

![image](https://github.com/touying-typ/touying/assets/34951714/9ba71f54-2a5d-4144-996c-4a42833cc5cc)
