### PR TITLE
feat: better show-slides mode

### DIFF
--- a/themes/university.typ
+++ b/themes/university.typ
@@ -186,7 +186,7 @@
   if title-slide {
     (self.methods.title-slide)(self: self)
   }
-  (self.methods.touying-slides)(self: self, cutting-out: true, ..args)
+  (self.methods.touying-slides)(self: self, ..args)
 }
 
 #let register(

--- a/utils/utils.typ
+++ b/utils/utils.typ
@@ -27,6 +27,25 @@
   return methods
 }
 
+// touying wrapper mark
+#let touying-wrapper(name, fn, ..args) = {
+  metadata((
+    kind: "touying-wrapper",
+    name: name,
+    fn: fn,
+    args: args,
+  ))
+}
+
+#let slides(self) = {
+  let m = methods(self)
+  let res = (:)
+  for key in m.keys() {
+    res.insert(key, touying-wrapper.with(key, m.at(key)))
+  }
+  return res
+}
+
 // Utils: unify section
 #let unify-section(section) = {
   if section == none {
@@ -50,6 +69,15 @@
   } else {
     return section
   }
+}
+
+// Utils: trim
+#let trim(arr) = {
+  let i = 0
+  while arr.len() != i and arr.at(i) in ([], [ ], parbreak(), linebreak()) {
+    i += 1
+  }
+  arr.slice(i)
 }
 
 // Type: is sequence


### PR DESCRIPTION
As mentioned in #7 and #8, we plan to implement a more powerful show-slides mode, which can be broadly divided into the following three parts:

1. Using heading 1, 2, 3 to respectively correspond to section, subsection, and title. We no longer need to mix subsection and title using the second-level heading. **(This is a breaking change)**
2. Simplifying the implementation of the slides mode with themes, eliminating the need to register the `slide-in-slides` method. Instead, we adopt the "convention over configuration" philosophy to simplify the implementation. Specifically, in the slides mode, the default call is made to the `self.methods.slide` method. Additionally, if we have a `self.methods.touying-new-section-slide` method, `= Section` will be automatically translated into `self.methods.touying-new-section-slide[Section]`.
3. Through syntax like `#let (slide, focus-slide) = utils.slides(s)`, we can use syntax like `#slide[]` and `#focus-slide[]` in the show-slides mode, providing more powerful functionality and clearer structure. In this syntax, section, subsection, and title will be automatically passed into `#slide[]`. (Because `"slide"` is registered in `self.slides = ("slide",)`, it can be automatically passed in)

Here is a specific example:

```typst
#import "../lib.typ": *

#let s = themes.university.register(s)
#let s = (s.methods.info)(
  self: s,
  title: [Title],
  subtitle: [Subtitle],
  author: [Authors],
  date: datetime.today(),
  institution: [Institution],
)
#let (init, slides) = utils.methods(s)
#show: init

#let (slide, focus-slide) = utils.slides(s)
#show: slides

= Section

== Subsection

=== Title

#slide[
  AAA
]

#slide[
  BBB
]

#focus-slide[
  CCC
]
```

![image](https://github.com/touying-typ/touying/assets/34951714/814e8bc0-d06c-4496-804b-2e01416501b5)

cc @fbob and @HPDell