### PR TITLE
refactor: rename `s` to `store`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ To use Touying, you only need to include the following code in your document:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -94,7 +94,7 @@ It's simple. Congratulations on creating your first Touying slide! 🎉
 
 **Tip:** You can use Typst syntax like `#import "config.typ": *` or `#include "content.typ"` to implement Touying's multi-file architecture.
 
-**Warning:** The comma in `#let (slide,) = utils.slides(s)` is necessary for the unpacking syntax.
+**Warning:** The comma in `#let (slide,) = utils.slides(store)` is necessary for the unpacking syntax.
 
 
 ## More Complex Examples
@@ -113,11 +113,11 @@ In fact, Touying provides various styles for writing slides. For example, the ab
 // Register university theme
 // You can remove the theme registration or replace other themes
 // it can still work normally
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 
 // Global information configuration
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
@@ -126,13 +126,13 @@ In fact, Touying provides various styles for writing slides. For example, the ab
 )
 
 // Extract methods
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
 // Extract slide functions
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Animation
@@ -262,8 +262,8 @@ In fact, Touying provides various styles for writing slides. For example, the ab
 
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 == Appendix
 

--- a/docs/docs/build-your-own-theme.md
+++ b/docs/docs/build-your-own-theme.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 Creating your own theme with Touying might seem a bit complex initially due to the introduction of various concepts. However, fear not; if you successfully create a custom theme with Touying, you'll likely experience the convenience and powerful customization features it offers. You can refer to the [source code of existing themes](https://github.com/touying-typ/touying/tree/main/themes) for guidance. The key steps to implement are:
 
-- Customize the `register` function to initialize the global singleton `s`.
+- Customize the `register` function to initialize the global singleton `store`.
 - Customize the `init` method.
 - Define a color theme by modifying the `self.colors` member variable.
 - Customize the `alert` method (optional).
@@ -71,13 +71,13 @@ Generally, the first step in creating slides is to determine font size and page 
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9")
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = bamboo.register(store, aspect-ratio: "16-9")
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -93,9 +93,9 @@ As you can see, we created a `register` function and passed an `aspect-ratio` pa
 
 In addition, we registered a `self.methods.init` method, which can be used for some global style settings. For example, in this case, we added `set text(size: 20pt)` to set the font size. You can also place additional global style settings here, such as `set par(justify: true)`. Since the `init` function is placed inside `self.methods`, it is a method, not a regular function. Therefore, we need to add the parameter `self: none` to use it properly.
 
-As you can see, later in `main.typ`, we apply the global style settings in `init` using `#show: init`, where `init` is bound and unpacked through `utils.methods(s)`.
+As you can see, later in `main.typ`, we apply the global style settings in `init` using `#show: init`, where `init` is bound and unpacked through `utils.methods(store)`.
 
-If you pay extra attention, you'll notice that the `register` function has an independent `self` at the end. This actually represents returning the modified `self` as the return value, which will be saved in `#let s = ..`. This line is therefore indispensable.
+If you pay extra attention, you'll notice that the `register` function has an independent `self` at the end. This actually represents returning the modified `self` as the return value, which will be saved in `#let store = ..`. This line is therefore indispensable.
 
 ## Color Theme
 
@@ -133,7 +133,7 @@ After adding the color theme, we can access the color using syntax like `self.co
 It's worth noting that users can change the theme color at any time using:
 
 ```typst
-#let s = (s.methods.colors)(self: s, primary: rgb("#3578B9"))
+#let store = (store.methods.colors)(self: store, primary: rgb("#3578B9"))
 ```
 
 This flexibility demonstrates Touying's powerful customization capabilities.
@@ -233,13 +233,13 @@ We also need to customize a `slide` method that accepts `slide(self: none, title
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = bamboo.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -389,21 +389,21 @@ Finally, we update the `slides(self: none, title-slide: true, slide-level: 1, ..
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = bamboo.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = First Section

--- a/docs/docs/code-styles.md
+++ b/docs/docs/code-styles.md
@@ -11,11 +11,11 @@ If we only need simplicity, we can directly input content under the heading, jus
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -37,18 +37,18 @@ PS: We can use the `#slides-end` marker to signify the end of `#show: slides`.
 
 ## Block Style
 
-Many times, using simple style alone cannot achieve all the functions we need. For more powerful features and clearer structure, we can also use block style in the form of `#slide[...]`. The `#slide` function needs to be unpacked using the syntax `#let (slide,) = utils.slides(s)` to be used correctly after `#show: slides`.
+Many times, using simple style alone cannot achieve all the functions we need. For more powerful features and clearer structure, we can also use block style in the form of `#slide[...]`. The `#slide` function needs to be unpacked using the syntax `#let (slide,) = utils.slides(store)` to be used correctly after `#show: slides`.
 
 For example, the previous example can be transformed into:
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -73,19 +73,19 @@ There are many advantages to doing this:
 
 ## Convention Over Configuration
 
-You may have noticed that when using the simple theme, using a level-one heading automatically creates a new section slide. This is because the simple theme registers an `s.methods.touying-new-section-slide` method, so Touying will automatically call this method.
+You may have noticed that when using the simple theme, using a level-one heading automatically creates a new section slide. This is because the simple theme registers an `store.methods.touying-new-section-slide` method, so Touying will automatically call this method.
 
 If we don't want it to automatically create such a section slide, we can delete this method:
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#(s.methods.touying-new-section-slide = none)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#(store.methods.touying-new-section-slide = none)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -108,19 +108,19 @@ Similarly, we can register a new section slide:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#(s.methods.touying-new-section-slide = (self: none, section, ..args) => {
+#let store = themes.simple.register(store)
+#(store.methods.touying-new-section-slide = (self: none, section, ..args) => {
   self = utils.empty-page(self)
-  (s.methods.touying-slide)(self: self, section: section, {
+  (store.methods.touying-slide)(self: self, section: section, {
     set align(center + horizon)
     set text(size: 2em, fill: s.colors.primary, style: "italic", weight: "bold")
     section
   }, ..args)
 })
-#let (init, slides, touying-outline) = utils.methods(s)
+#let (init, slides, touying-outline) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -136,21 +136,21 @@ Hello, Typst!
 
 ![image](https://github.com/touying-typ/touying/assets/34951714/5305efda-0cd4-42eb-9f2e-89abc30b6ca2)
 
-Similarly, we can modify `s.methods.touying-new-subsection-slide` to do the same for `subsection`.
+Similarly, we can modify `store.methods.touying-new-subsection-slide` to do the same for `subsection`.
 
-In fact, besides `s.methods.touying-new-section-slide`, another special `slide` function is the `s.methods.slide` function, which will be called by default in simple style when `#slide[...]` is not explicitly used.
+In fact, besides `store.methods.touying-new-section-slide`, another special `slide` function is the `store.methods.slide` function, which will be called by default in simple style when `#slide[...]` is not explicitly used.
 
 Also, since `#slide[...]` is registered in `s.slides = ("slide",)`, the `section`, `subsection`, and `title` parameters will be automatically passed, while others like `#focus-slide[...]` will not automatically receive these three parameters.
 
 :::tip[Principle]
 
-In fact, you can also not use `#show: slides` and `utils.slides(s)`, but only use `utils.methods(s)`, for example:
+In fact, you can also not use `#show: slides` and `utils.slides(store)`, but only use `utils.methods(store)`, for example:
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, touying-outline, slide) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, touying-outline, slide) = utils.methods(store)
 #show: init
 
 #slide(section: [Title], title: [First Slide])[

--- a/docs/docs/dynamic/cover.md
+++ b/docs/docs/dynamic/cover.md
@@ -8,7 +8,7 @@ As you already know, both `uncover` and `#pause` use the `cover` function to con
 
 ## Default Cover Function: `hide`
 
-The `cover` function is a method stored in `s.methods.cover`, which is later used by `uncover` and `#pause`.
+The `cover` function is a method stored in `store.methods.cover`, which is later used by `uncover` and `#pause`.
 
 The default `cover` function is the [hide](https://typst.app/docs/reference/layout/hide/) function. This function makes the internal content invisible without affecting the layout.
 
@@ -17,7 +17,7 @@ The default `cover` function is the [hide](https://typst.app/docs/reference/layo
 In some cases, you might want to use your own `cover` function. In that case, you can set your own `cover` function using:
 
 ```typst
-let s = (s.methods.update-cover)(self: s, is-method: true, cover-fn)
+let store = (store.methods.update-cover)(self: store, is-method: true, cover-fn)
 ```
 
 Here, if you set `is-method: false`, Touying will wrap `cover-fn` into a method for you.
@@ -27,7 +27,7 @@ Here, if you set `is-method: false`, Touying will wrap `cover-fn` into a method 
 Touying supports a semi-transparent cover function, which can be enabled by adding:
 
 ```typst
-#let s = (s.methods.enable-transparent-cover)(self: s)
+#let store = (store.methods.enable-transparent-cover)(self: store)
 ```
 
 You can adjust the transparency through the `alpha: ..` parameter.
@@ -43,7 +43,7 @@ Note that the `transparent-cover` here does not preserve text layout like `hide`
 The `enable-transparent-cover` method is defined as:
 
 ```typst
-#let s.methods.enable-transparent-cover = (
+#let store.methods.enable-transparent-cover = (
   self: none,
   constructor: rgb,
   alpha: 85%,

--- a/docs/docs/dynamic/handout.md
+++ b/docs/docs/dynamic/handout.md
@@ -11,5 +11,5 @@ The handout mode differs from the regular mode as it doesn't require intricate a
 Enabling handout mode is simple:
 
 ```typst
-#let s = (s.methods.enable-handout-mode)(self: s)
+#let store = (store.methods.enable-handout-mode)(self: store)
 ```

--- a/docs/docs/dynamic/other.md
+++ b/docs/docs/dynamic/other.md
@@ -18,11 +18,11 @@ Here's an example:
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/docs/external/pdfpc.md
+++ b/docs/docs/external/pdfpc.md
@@ -21,7 +21,7 @@ For example, you can add notes using `#pdfpc.speaker-note("This is a note that o
 To add pdfpc configurations, you can use
 
 ```typst
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),

--- a/docs/docs/global-settings.md
+++ b/docs/docs/global-settings.md
@@ -21,8 +21,8 @@ self.methods.init = (self: none, body) => {
 If you are not a theme creator but want to add your own global styles to your slides, you can simply place them after `#show: init` and before `#show: slides`. For example, the metropolis theme recommends adding the following global styles:
 
 ```typst
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9")
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9")
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 // global styles
@@ -32,7 +32,7 @@ If you are not a theme creator but want to add your own global styles to your sl
 #set par(justify: true)
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -56,8 +56,8 @@ Like Beamer, Touying, through an OOP-style unified API design, can help you bett
 You can set the title, subtitle, author, date, and institution information for slides using:
 
 ```typst
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
@@ -71,13 +71,13 @@ In subsequent slides, you can access them through `s.info` or `self.info`.
 This information is generally used in the title-slide, header, and footer of the theme, for example:
 
 ```typst
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
 ```
 
 The `date` can accept `datetime` format or `content` format, and the display format for the `datetime` format can be changed using:
 
 ```typst
-#let s = (s.methods.datetime-format)(self: s, "[year]-[month]-[day]")
+#let store = (store.methods.datetime-format)(self: store, "[year]-[month]-[day]")
 ```
 
 :::tip[Principle]
@@ -86,10 +86,10 @@ Here, we will introduce a bit of OOP concept in Touying.
 
 You should know that Typst is a typesetting language that supports incremental rendering, which means Typst caches the results of previous function calls. This requires that Typst consists of pure functions, meaning functions that do not change external variables. Thus, it is challenging to modify a global variable in the true sense, even with the use of `state` or `counter`. This would require the use of `locate` with callback functions to obtain the values inside, and this approach would have a significant impact on performance.
 
-Touying does not use `state` or `counter` and does not violate the principle of pure functions in Typst. Instead, it uses a clever approach in an object-oriented style, maintaining a global singleton `s`. In Touying, an object refers to a Typst dictionary with its own member variables and methods. We agree that methods all have a named parameter `self` for passing the object itself, and methods are placed in the `.methods` domain. With this concept, it becomes easier to write methods to update `info`:
+Touying does not use `state` or `counter` and does not violate the principle of pure functions in Typst. Instead, it uses a clever approach in an object-oriented style, maintaining a global singleton `store`. In Touying, an object refers to a Typst dictionary with its own member variables and methods. We agree that methods all have a named parameter `self` for passing the object itself, and methods are placed in the `.methods` domain. With this concept, it becomes easier to write methods to update `info`:
 
 ```typst
-#let s = (
+#let store = (
   info: (:),
   methods: (
     // update info
@@ -100,38 +100,38 @@ Touying does not use `state` or `counter` and does not violate the principle of 
   )
 )
 
-#let s = (s.methods.info)(self: s, title: [title])
+#let store = (store.methods.info)(self: store, title: [title])
 
 Title is #s.info.title
 ```
 
-Now you can understand the purpose of the `utils.methods()` function: to bind `self` to all methods of `s` and return it, simplifying the subsequent usage through unpacking syntax.
+Now you can understand the purpose of the `utils.methods()` function: to bind `self` to all methods of `store` and return it, simplifying the subsequent usage through unpacking syntax.
 
 ```typst
-#let (init, slides, alert) = utils.methods(s)
+#let (init, slides, alert) = utils.methods(store)
 ```
 :::
 
 ## State Initialization
 
-In general, the two ways mentioned above are sufficient for adding global settings. However, there are still situations where we need to initialize counters or states. If you place this code before `#show: slides`, a blank page will be created, which is something we don't want to see. In such cases, you can use the `s.methods.append-preamble` method. For example, when using the codly package:
+In general, the two ways mentioned above are sufficient for adding global settings. However, there are still situations where we need to initialize counters or states. If you place this code before `#show: slides`, a blank page will be created, which is something we don't want to see. In such cases, you can use the `store.methods.append-preamble` method. For example, when using the codly package:
 
 ```typst
 #import "@preview/touying:0.3.1": *
 #import "@preview/codly:0.2.0": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.append-preamble)(self: s)[
+#let store = themes.simple.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.append-preamble)(self: store)[
   #codly(languages: (
     rust: (name: "Rust", icon: "\u{fa53}", color: rgb("#CE412B")),
   ))
 ]
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show heading.where(level: 2): set block(below: 1em)
 #show: init
 #show: codly-init.with()
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 #slide[
@@ -151,7 +151,7 @@ Or when configuring Pdfpc:
 ```typst
 // Pdfpc configuration
 // typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),

--- a/docs/docs/integration/cetz.md
+++ b/docs/docs/integration/cetz.md
@@ -18,11 +18,11 @@ An example:
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/docs/integration/codly.md
+++ b/docs/docs/integration/codly.md
@@ -4,24 +4,24 @@ sidebar_position: 5
 
 # Codly
 
-When using Codly, we should initialize it using the `s.methods.append-preamble` method.
+When using Codly, we should initialize it using the `store.methods.append-preamble` method.
 
 ```typst
 #import "@preview/touying:0.3.1": *
 #import "@preview/codly:0.2.0": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.append-preamble)(self: s)[
+#let store = themes.simple.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.append-preamble)(self: store)[
   #codly(languages: (
     rust: (name: "Rust", icon: "\u{fa53}", color: rgb("#CE412B")),
   ))
 ]
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show heading.where(level: 2): set block(below: 1em)
 #show: init
 #show: codly-init.with()
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 #slide[

--- a/docs/docs/integration/fletcher.md
+++ b/docs/docs/integration/fletcher.md
@@ -16,11 +16,11 @@ An example:
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/docs/integration/pinit.md
+++ b/docs/docs/integration/pinit.md
@@ -38,7 +38,7 @@ An example of shared usage with Touying:
 #import "@preview/pinit:0.1.3": *
 
 #(s.page-args.paper = "presentation-4-3")
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show: init
 
 #set text(size: 20pt, font: "Calibri", ligatures: false)
@@ -58,7 +58,7 @@ An example of shared usage with Touying:
   body
 }
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 // Main body

--- a/docs/docs/layout.md
+++ b/docs/docs/layout.md
@@ -112,7 +112,7 @@ Similarly, if you are not satisfied with the header or footer style of a theme, 
 #(s.page-args.footer = [Custom Footer])
 ```
 
-to replace it. However, please note that if you replace the page parameters in this way, you need to place it before `#let (slide,) = utils.slides(s)`, or you need to call `#let (slide,) = utils.slides(s)` again.
+to replace it. However, please note that if you replace the page parameters in this way, you need to place it before `#let (slide,) = utils.slides(store)`, or you need to call `#let (slide,) = utils.slides(store)` again.
 
 :::warning[Warning]
 
@@ -132,7 +132,7 @@ For example, suppose we decide to add the GitHub icon to the metropolis theme. W
 #import "@preview/touying:0.3.1": *
 #import "@preview/octique:0.1.0": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9")
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9")
 #(s.page-args.header = self => {
   // display the original header
   utils.call-or-display(self, s.page-args.header)
@@ -141,7 +141,7 @@ For example, suppose we decide to add the GitHub icon to the metropolis theme. W
     #octique("mark-github", color: rgb("#fafafa"), width: 1.5em, height: 1.5em)
   ]
 })
-#let (init, slide) = utils.methods(s)
+#let (init, slide) = utils.methods(store)
 #show: init
 
 #slide(title: [Title])[

--- a/docs/docs/progress/counters.md
+++ b/docs/docs/progress/counters.md
@@ -32,8 +32,8 @@ You can use
 
 ```typst
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.methods(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.methods(store)
 
 #slide[
   appendix
@@ -42,4 +42,4 @@ You can use
 
 syntax to enter the appendix.
 
-Additionally, `#let s = (s.methods.appendix-in-outline)(self: s, false)` can be used to hide the appendix section from the outline.
+Additionally, `#let store = (store.methods.appendix-in-outline)(self: store, false)` can be used to hide the appendix section from the outline.

--- a/docs/docs/sections.md
+++ b/docs/docs/sections.md
@@ -13,11 +13,11 @@ Generally, level 1, level 2, and level 3 headings correspond to section, subsect
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.dewdrop.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Section
@@ -36,11 +36,11 @@ However, often we don't need subsections, and we can use level 1 and level 2 hea
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.university.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Section
@@ -61,10 +61,10 @@ Displaying a table of contents in Touying is straightforward:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let (init, slides, alert, touying-outline) = utils.methods(s)
+#let (init, slides, alert, touying-outline) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(slide-level: 2)
 
 = Section

--- a/docs/docs/start.md
+++ b/docs/docs/start.md
@@ -11,11 +11,11 @@ To use Touying, you just need to include the following in your document:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -35,7 +35,7 @@ It's that simple! You've created your first Touying slides. Congratulations! ðŸŽ
 
 **Tip:** You can use Typst syntax like `#import "config.typ": *` or `#include "content.typ"` to implement Touying's multi-file architecture.
 
-**Warning:** The comma in `#let (slide,) = utils.slides(s)` is necessary for the unpacking syntax.
+**Warning:** The comma in `#let (slide,) = utils.slides(store)` is necessary for the unpacking syntax.
 
 ## More Complex Examples
 
@@ -46,7 +46,7 @@ In fact, Touying provides various styles for slide writing. You can also use the
 Touying offers many built-in themes to easily create beautiful slides. For example, in this case:
 
 ```
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 ```
 
 you can use the university theme. For more detailed tutorials on themes, you can refer to the following sections.
@@ -63,11 +63,11 @@ you can use the university theme. For more detailed tutorials on themes, you can
 // Register university theme
 // You can remove the theme registration or replace other themes
 // it can still work normally
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 
 // Global information configuration
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
@@ -77,7 +77,7 @@ you can use the university theme. For more detailed tutorials on themes, you can
 
 // Pdfpc configuration
 // typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),
@@ -94,13 +94,13 @@ you can use the university theme. For more detailed tutorials on themes, you can
 ))
 
 // Extract methods
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
 // Extract slide functions
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Animation
@@ -224,8 +224,8 @@ you can use the university theme. For more detailed tutorials on themes, you can
 
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 == Appendix
 
@@ -239,7 +239,7 @@ you can use the university theme. For more detailed tutorials on themes, you can
 Touying offers many built-in themes to easily create beautiful slides. For example, in this case:
 
 ```
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 ```
 
 you can use the university theme. For more detailed tutorials on themes, you can refer to the following sections.

--- a/docs/docs/themes/dewdrop.md
+++ b/docs/docs/themes/dewdrop.md
@@ -17,28 +17,28 @@ You can initialize it using the following code:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(
-  s,
+#let store = themes.dewdrop.register(
+  store,
   aspect-ratio: "16-9",
   footer: [Dewdrop],
   navigation: "mini-slides",
   // navigation: "sidebar",
   // navigation: none,
 )
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -64,8 +64,8 @@ The Dewdrop theme also provides an `#alert[..]` function, which you can use with
 Dewdrop uses the following default color theme:
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   neutral-darkest: rgb("#000000"),
   neutral-dark: rgb("#202020"),
   neutral-light: rgb("#f3f3f3"),
@@ -74,7 +74,7 @@ Dewdrop uses the following default color theme:
 )
 ```
 
-You can modify this color theme using `#let s = (s.methods.colors)(self: s, ..)`.
+You can modify this color theme using `#let store = (store.methods.colors)(self: store, ..)`.
 
 ## Slide Function Family
 
@@ -153,21 +153,21 @@ PS: You can modify the outline title using `#(s.outline-title = [Outline])`.
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(s, aspect-ratio: "16-9", footer: [Dewdrop])
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.dewdrop.register(store, aspect-ratio: "16-9", footer: [Dewdrop])
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -189,27 +189,27 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(
-  s,
+#let store = themes.dewdrop.register(
+  store,
   aspect-ratio: "16-9",
   footer: [Dewdrop],
   navigation: "mini-slides",
   // navigation: none,
 )
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Section A
@@ -255,8 +255,8 @@ Hello, Typst!
 ]
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 = Appendix
 

--- a/docs/docs/themes/metropolis.md
+++ b/docs/docs/themes/metropolis.md
@@ -17,21 +17,21 @@ You can initialize it using the following code:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -50,8 +50,8 @@ The Metropolis theme also provides an `#alert[..]` function, which you can use w
 Metropolis uses the following default color theme:
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   neutral-lightest: rgb("#fafafa"),
   primary-dark: rgb("#23373b"),
   secondary-light: rgb("#eb811b"),
@@ -59,7 +59,7 @@ Metropolis uses the following default color theme:
 )
 ```
 
-You can modify this color theme using `#let s = (s.methods.colors)(self: s, ..)`.
+You can modify this color theme using `#let store = (store.methods.colors)(self: store, ..)`.
 
 ## Slide Function Family
 
@@ -124,17 +124,17 @@ PS: You can modify the outline title using `#(s.outline-title = [Outline])`.
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slide, slides, title-slide, new-section-slide, focus-slide, touying-outline, alert) = utils.methods(s)
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slide, slides, title-slide, new-section-slide, focus-slide, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
@@ -160,16 +160,16 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #set text(font: "Fira Sans", weight: "light", size: 20pt)
@@ -178,7 +178,7 @@ Hello, Typst!
 #set par(justify: true)
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -214,8 +214,8 @@ Hello, Typst!
 ]
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 = Appendix
 

--- a/docs/docs/themes/simple.md
+++ b/docs/docs/themes/simple.md
@@ -17,12 +17,12 @@ You can initialize it using the following code:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -98,12 +98,12 @@ You can set it using `#show: slides.with(..)`.
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -125,11 +125,11 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 #title-slide[

--- a/docs/docs/themes/university.md
+++ b/docs/docs/themes/university.md
@@ -15,19 +15,19 @@ You can initialize the University theme using the following code:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -43,15 +43,15 @@ Additionally, the University theme provides an `#alert[..]` function, which you 
 The University theme defaults to the following color theme:
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   primary: rgb("#04364A"),
   secondary: rgb("#176B87"),
   tertiary: rgb("#448C95"),
 )
 ```
 
-You can modify this color theme using `#let s = (s.methods.colors)(self: s, ..)`.
+You can modify this color theme using `#let store = (store.methods.colors)(self: store, ..)`.
 
 ## Slide Function Family
 
@@ -120,19 +120,19 @@ You can set these parameters using `#show: slides.with(..)`.
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -154,19 +154,19 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides.with(title-slide: false)
 
 #title-slide(authors: ([Author A], [Author B]))

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/build-your-own-theme.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/build-your-own-theme.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 使用 Touying 创建一个自己的主题是一件略显复杂的事情，因为我们引入了许多的概念。不过请放心，如果您真的用 Touying 创建了一个自己的主题，也许您就可以深切地感受到 Touying 提供的便利的功能的和强大的可定制性。您可以参考 [主题的源代码](https://github.com/touying-typ/touying/tree/main/themes)，主要需要实现的就是：
 
-- 自定义 `register` 函数，初始化全局单例 `s`；
+- 自定义 `register` 函数，初始化全局单例 `store`；
 - 自定义 `init` 方法；
 - 自定义颜色主题，即修改 `self.colors` 成员变量；
 - 自定义 `alert` 方法，可选；
@@ -72,13 +72,13 @@ sidebar_position: 10
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9")
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = bamboo.register(store, aspect-ratio: "16-9")
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -94,9 +94,9 @@ sidebar_position: 10
 
 除此之外，我们还注册了一个 `self.methods.init` 方法，它可以用来进行一些全局的样式设置，例如在此处，我们加上了 `set text(size: 20pt)` 来设置文字大小。你也可以在这里放置一些额外的全局样式设置，例如 `set par(justify: true)` 等。由于 `init` 函数被放置到了 `self.methods` 里，是一个方法，而非普通函数，因此我们需要加上 `self: none` 参数才能正常使用。
 
-如您所见，后续在 `main.typ` 中，我们会通过 `#show: init` 来应用 `init` 方法里面的全局样式设置，其中 `init` 函数是通过 `utils.methods(s)` 绑定并解包而来的。
+如您所见，后续在 `main.typ` 中，我们会通过 `#show: init` 来应用 `init` 方法里面的全局样式设置，其中 `init` 函数是通过 `utils.methods(store)` 绑定并解包而来的。
 
-如果您多加注意，您会发现 `register` 函数最后有一行独立的 `self`，这其实是代表了将修改后的 `self` 作为返回值返回，后续会被保存在 `#let s = ..` 中，因此这一行是不可或缺的。
+如果您多加注意，您会发现 `register` 函数最后有一行独立的 `self`，这其实是代表了将修改后的 `self` 作为返回值返回，后续会被保存在 `#let store = ..` 中，因此这一行是不可或缺的。
 
 
 ## 颜色主题
@@ -135,10 +135,10 @@ sidebar_position: 10
 并且有一点值得注意，用户可以随时在 `main.typ` 里通过
 
 ```typst
-#let s = (s.methods.colors)(self: s, primary: rgb("#3578B9"))
+#let store = (store.methods.colors)(self: store, primary: rgb("#3578B9"))
 ```
 
-这样的方式修改主题色，其中这句语句需要放在 `register(s)` 之后，以及 `utils.methods(s)` 之前。
+这样的方式修改主题色，其中这句语句需要放在 `register(s)` 之后，以及 `utils.methods(store)` 之前。
 
 这种随时更换颜色主题的内容，正是 Touying 强大可定制性的体现。
 
@@ -241,13 +241,13 @@ self.methods.alert = (self: none, it) => text(fill: self.colors.primary, it)
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = bamboo.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -396,21 +396,21 @@ self.methods.alert = (self: none, it) => text(fill: self.colors.primary, it)
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = bamboo.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = First Section

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/code-styles.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/code-styles.md
@@ -11,11 +11,11 @@ sidebar_position: 4
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -38,18 +38,18 @@ PS：我们可以使用 `#slides-end` 记号来标志 `#show: slides` 的结束�
 
 ## 块风格
 
-很多时候，仅仅使用简单风格并不能实现我们需要的所有功能，为了更强大的功能和更清晰的结构，我们同样可以使用 `#slide[...]` 形式的块风格，其中 `#slide` 函数需要使用 `#let (slide,) = utils.slides(s)` 语法进行解包，才能正常在 `#show: slides` 后使用。
+很多时候，仅仅使用简单风格并不能实现我们需要的所有功能，为了更强大的功能和更清晰的结构，我们同样可以使用 `#slide[...]` 形式的块风格，其中 `#slide` 函数需要使用 `#let (slide,) = utils.slides(store)` 语法进行解包，才能正常在 `#show: slides` 后使用。
 
 例如上面的例子就可以改造成
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -75,19 +75,19 @@ PS：我们可以使用 `#slides-end` 记号来标志 `#show: slides` 的结束�
 
 ## 约定优于配置
 
-你可能注意到了，在使用 simple 主题时，我们使用一级标题会自动创建一个 section slide，这是因为 simple 主题注册了一个 `s.methods.touying-new-section-slide` 方法，因此 touying 会默认调用这个方法。
+你可能注意到了，在使用 simple 主题时，我们使用一级标题会自动创建一个 section slide，这是因为 simple 主题注册了一个 `store.methods.touying-new-section-slide` 方法，因此 touying 会默认调用这个方法。
 
 如果我们不希望它自动创建这样一个 section slide，我们可以将这个方法删除：
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#(s.methods.touying-new-section-slide = none)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#(store.methods.touying-new-section-slide = none)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -110,19 +110,19 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#(s.methods.touying-new-section-slide = (self: none, section, ..args) => {
+#let store = themes.simple.register(store)
+#(store.methods.touying-new-section-slide = (self: none, section, ..args) => {
   self = utils.empty-page(self)
-  (s.methods.touying-slide)(self: self, section: section, {
+  (store.methods.touying-slide)(self: self, section: section, {
     set align(center + horizon)
     set text(size: 2em, fill: s.colors.primary, style: "italic", weight: "bold")
     section
   }, ..args)
 })
-#let (init, slides, touying-outline) = utils.methods(s)
+#let (init, slides, touying-outline) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -138,21 +138,21 @@ Hello, Typst!
 
 ![image](https://github.com/touying-typ/touying/assets/34951714/5305efda-0cd4-42eb-9f2e-89abc30b6ca2)
 
-同样地，我们也可以修改 `s.methods.touying-new-subsection-slide` 来对 `subsection` 做同样的事。
+同样地，我们也可以修改 `store.methods.touying-new-subsection-slide` 来对 `subsection` 做同样的事。
 
-实际上，除了 `s.methods.touying-new-section-slide`，另一个特殊的 `slide` 函数就是 `s.methods.slide` 函数，它会在简单风格里没有显示使用 `#slide[...]` 的情况下默认被调用。
+实际上，除了 `store.methods.touying-new-section-slide`，另一个特殊的 `slide` 函数就是 `store.methods.slide` 函数，它会在简单风格里没有显示使用 `#slide[...]` 的情况下默认被调用。
 
 同时，由于 `#slide[...]` 被注册在了 `s.slides = ("slide",)` 里，因此 `section`，`subsection` 和 `title` 参数会被自动传入，而其他的如 `#focus-slide[...]` 则不会自动传入这三个参数。
 
 :::tip[原理]
 
-实际上，你也可以不使用 `#show: slides` 和 `utils.slides(s)`，而是只使用 `utils.methods(s)`，例如
+实际上，你也可以不使用 `#show: slides` 和 `utils.slides(store)`，而是只使用 `utils.methods(store)`，例如
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, touying-outline, slide) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, touying-outline, slide) = utils.methods(store)
 #show: init
 
 #slide(section: [Title], title: [First Slide])[

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/dynamic/cover.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/dynamic/cover.md
@@ -9,7 +9,7 @@ sidebar_position: 4
 
 ## 默认 Cover 函数：`hide`
 
-`cover` 函数是保存在 `s.methods.cover` 的一个方法，后续 `uncover` 和 `#pause` 均会在这里取出 `cover` 函数来使用。
+`cover` 函数是保存在 `store.methods.cover` 的一个方法，后续 `uncover` 和 `#pause` 均会在这里取出 `cover` 函数来使用。
 
 默认的 `cover` 函数是 [hide](https://typst.app/docs/reference/layout/hide/) 函数，这个函数能将内部的内容更改为不可见的，且不会影响布局。
 
@@ -19,7 +19,7 @@ sidebar_position: 4
 有的情况下，您想用您自己的 `cover` 函数，那么您可以通过
 
 ```typst
-let s = (s.methods.update-cover)(self: s, is-method: true, cover-fn)
+#let store = (store.methods.update-cover)(self: store, is-method: true, cover-fn)
 ```
 
 方法来设置您自己的 `cover` 函数，其中如果设置 `is-method: false`，则 Touying 会帮您将 `cover-fn` 包装成一个方法。
@@ -30,7 +30,7 @@ let s = (s.methods.update-cover)(self: s, is-method: true, cover-fn)
 Touying 提供了半透明 Cover 函数的支持，只需要加入
 
 ```typst
-#let s = (s.methods.enable-transparent-cover)(self: s)
+#let store = (store.methods.enable-transparent-cover)(self: store)
 ```
 
 即可开启，其中你可以通过 `alpha: ..` 参数调节透明度。
@@ -48,7 +48,7 @@ Touying 提供了半透明 Cover 函数的支持，只需要加入
 `enable-transparent-cover` 方法定义为
 
 ```typst
-#let s.methods.enable-transparent-cover = (
+#let store.methods.enable-transparent-cover = (
   self: none,
   constructor: rgb,
   alpha: 85%,

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/dynamic/handout.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/dynamic/handout.md
@@ -11,5 +11,5 @@ sidebar_position: 6
 开启讲义模式是很简单的：
 
 ```typst
-#let s = (s.methods.enable-handout-mode)(self: s)
+#let store = (store.methods.enable-handout-mode)(self: store)
 ```

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/dynamic/other.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/dynamic/other.md
@@ -18,11 +18,11 @@ Touying 还提供了 `touying-reducer`，它能为 cetz 与 fletcher 加入 `pau
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/external/pdfpc.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/external/pdfpc.md
@@ -21,7 +21,7 @@ Touying 与 [Polylux](https://polylux.dev/book/external/pdfpc.html) 保持一致
 为了加入 pdfpc 配置，你可以使用
 
 ```typst
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/global-settings.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/global-settings.md
@@ -21,8 +21,8 @@ self.methods.init = (self: none, body) => {
 如果你并非一个主题制作者，而只是想给你的 slides 添加一些自己的全局样式，你可以简单地将它们放在 `#show: init` 之后，以及 `#show: slides` 之前，例如 metropolis 主题就推荐你自行加入以下全局样式：
 
 ```typst
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9")
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9")
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 // global styles
@@ -32,7 +32,7 @@ self.methods.init = (self: none, body) => {
 #set par(justify: true)
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -57,8 +57,8 @@ self.methods.init = (self: none, body) => {
 你可以通过
 
 ```typst
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
@@ -69,12 +69,12 @@ self.methods.init = (self: none, body) => {
 
 分别设置 slides 的标题、副标题、作者、日期和机构信息。在后续，你就可以通过 `s.info` 或 `self.info` 这样的方式访问它们。
 
-这些信息一般会在主题的 `title-slide`、`header` 和 `footer` 被使用到，例如 `#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)`。
+这些信息一般会在主题的 `title-slide`、`header` 和 `footer` 被使用到，例如 `#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)`。
 
 其中 `date` 可以接收 `datetime` 格式和 `content` 格式，并且 `datetime` 格式的日期显示格式，可以通过
 
 ```typst
-#let s = (s.methods.datetime-format)(self: s, "[year]-[month]-[day]")
+#let store = (store.methods.datetime-format)(self: store, "[year]-[month]-[day]")
 ```
 
 的方式更改。
@@ -85,10 +85,10 @@ self.methods.init = (self: none, body) => {
 
 您应该知道，Typst 是一个支持增量渲染的排版语言，也就是说，Typst 会缓存之前的函数调用结果，这就要求 Typst 里只有纯函数，即无法改变外部变量的函数。因此我们很难真正意义上地像 LaTeX 那样修改一个全局变量。即使是使用 `state` 或 `counter`，也需要使用 `locate` 与回调函数来获取里面的值，且实际上这种方式会对性能有很大的影响。
 
-Touying 并没有使用 `state` 和 `counter`，也没有违反 Typst 纯函数的原则，而是使用了一种巧妙的方式，并以面向对象风格的代码，维护了一个全局单例 `s`。在 Touying 中，一个对象指拥有自己的成员变量和方法的 Typst 字典，并且我们约定方法均有一个命名参数 `self` 用于传入对象自身，并且方法均放在 `.methods` 域里。有了这个理念，我们就不难写出更新 `info` 的方法了：
+Touying 并没有使用 `state` 和 `counter`，也没有违反 Typst 纯函数的原则，而是使用了一种巧妙的方式，并以面向对象风格的代码，维护了一个全局单例 `store`。在 Touying 中，一个对象指拥有自己的成员变量和方法的 Typst 字典，并且我们约定方法均有一个命名参数 `self` 用于传入对象自身，并且方法均放在 `.methods` 域里。有了这个理念，我们就不难写出更新 `info` 的方法了：
 
 ```
-#let s = (
+#let store = (
   info: (:),
   methods: (
     // update info
@@ -99,39 +99,39 @@ Touying 并没有使用 `state` 和 `counter`，也没有违反 Typst 纯函数�
   )
 )
 
-#let s = (s.methods.info)(self: s, title: [title])
+#let store = (store.methods.info)(self: store, title: [title])
 
 Title is #s.info.title
 ```
 
-这样，你也能够理解 `utils.methods()` 函数的用途了：将 `self` 绑定到 `s` 的所有方法上并返回，并通过解包语法简化后续的使用。
+这样，你也能够理解 `utils.methods()` 函数的用途了：将 `self` 绑定到 `store` 的所有方法上并返回，并通过解包语法简化后续的使用。
 
 ```typst
-#let (init, slides, alert) = utils.methods(s)
+#let (init, slides, alert) = utils.methods(store)
 ```
 :::
 
 
 ## 状态初始化
 
-一般而言，上面的两种方式就已经足够用于加入全局设置了，但是仍然会有部分情况，我们需要初始化 counters 或 states。如果将这些代码放在 `#show: slides` 之前，就会创建一个空白页，这是我们不想看见的，因此这时候我们就可以使用 `s.methods.append-preamble` 方法。例如在使用 codly 包的时候：
+一般而言，上面的两种方式就已经足够用于加入全局设置了，但是仍然会有部分情况，我们需要初始化 counters 或 states。如果将这些代码放在 `#show: slides` 之前，就会创建一个空白页，这是我们不想看见的，因此这时候我们就可以使用 `store.methods.append-preamble` 方法。例如在使用 codly 包的时候：
 
 ```typst
 #import "@preview/touying:0.3.1": *
 #import "@preview/codly:0.2.0": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.append-preamble)(self: s)[
+#let store = themes.simple.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.append-preamble)(self: store)[
   #codly(languages: (
     rust: (name: "Rust", icon: "\u{fa53}", color: rgb("#CE412B")),
   ))
 ]
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show heading.where(level: 2): set block(below: 1em)
 #show: init
 #show: codly-init.with()
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 #slide[
@@ -152,7 +152,7 @@ Title is #s.info.title
 ```typst
 // Pdfpc configuration
 // typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/integration/cetz.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/integration/cetz.md
@@ -18,11 +18,11 @@ Touying 提供了 `touying-reducer`，它能为 cetz 与 fletcher 加入 `pause`
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/integration/codly.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/integration/codly.md
@@ -4,24 +4,24 @@ sidebar_position: 5
 
 # Codly
 
-在使用 codly 的时候，我们应该使用 `s.methods.append-preamble` 方法进行初始化。
+在使用 codly 的时候，我们应该使用 `store.methods.append-preamble` 方法进行初始化。
 
 ```typst
 #import "@preview/touying:0.3.1": *
 #import "@preview/codly:0.2.0": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.append-preamble)(self: s)[
+#let store = themes.simple.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.append-preamble)(self: store)[
   #codly(languages: (
     rust: (name: "Rust", icon: "\u{fa53}", color: rgb("#CE412B")),
   ))
 ]
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show heading.where(level: 2): set block(below: 1em)
 #show: init
 #show: codly-init.with()
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 #slide[

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/integration/fletcher.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/integration/fletcher.md
@@ -16,11 +16,11 @@ Touying 提供了 `touying-reducer`，它能为 fletcher 加入 `pause` 和 `mea
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/integration/pinit.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/integration/pinit.md
@@ -40,7 +40,7 @@ A simple #pin(1)highlighted text#pin(2).
 #import "@preview/pinit:0.1.3": *
 
 #(s.page-args.paper = "presentation-4-3")
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show: init
 
 #set text(size: 20pt, font: "Calibri", ligatures: false)
@@ -60,7 +60,7 @@ A simple #pin(1)highlighted text#pin(2).
   body
 }
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 // Main body

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/layout.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/layout.md
@@ -112,11 +112,11 @@ sidebar_position: 5
 #(s.page-args.footer = [Custom Footer])
 ```
 
-这样方式进行更换。不过需要注意的是，如果这样更换了页面参数，你需要将其放在 `#let (slide,) = utils.slides(s)` 之前，否则就需要重新调用 `#let (slide,) = utils.slides(s)`。
+这样方式进行更换。不过需要注意的是，如果这样更换了页面参数，你需要将其放在 `#let (slide,) = utils.slides(store)` 之前，否则就需要重新调用 `#let (slide,) = utils.slides(store)`。
 
 :::warning[警告]
 
-因此，你不应该自己使用 `set page(..)` 命令，而是应该修改 `s` 内部的 `s.page-args` 成员变量。
+因此，你不应该自己使用 `set page(..)` 命令，而是应该修改 `store` 内部的 `s.page-args` 成员变量。
 
 :::
 
@@ -132,7 +132,7 @@ sidebar_position: 5
 #import "@preview/touying:0.3.1": *
 #import "@preview/octique:0.1.0": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9")
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9")
 #(s.page-args.header = self => {
   // display the original header
   utils.call-or-display(self, s.page-args.header)
@@ -141,7 +141,7 @@ sidebar_position: 5
     #octique("mark-github", color: rgb("#fafafa"), width: 1.5em, height: 1.5em)
   ]
 })
-#let (init, slide) = utils.methods(s)
+#let (init, slide) = utils.methods(store)
 #show: init
 
 #slide(title: [Title])[

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/progress/counters.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/progress/counters.md
@@ -35,8 +35,8 @@ Touying 的状态均放置于 `states` 命名空间下，包括所有的计数�
 
 ```typst
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.methods(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.methods(store)
 
 #slide[
   appendix
@@ -45,4 +45,4 @@ Touying 的状态均放置于 `states` 命名空间下，包括所有的计数�
 
 语法进入后记。
 
-并且 `#let s = (s.methods.appendix-in-outline)(self: s, false)` 可以让后记的 section 不显示在大纲中。
+并且 `#let store = (store.methods.appendix-in-outline)(self: store, false)` 可以让后记的 section 不显示在大纲中。

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/sections.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/sections.md
@@ -13,11 +13,11 @@ sidebar_position: 3
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.dewdrop.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Section
@@ -36,11 +36,11 @@ Hello, Touying!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.university.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Section
@@ -62,10 +62,10 @@ Hello, Touying!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let (init, slides, alert, touying-outline) = utils.methods(s)
+#let (init, slides, alert, touying-outline) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(slide-level: 2)
 
 = Section

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/start.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/start.md
@@ -11,11 +11,11 @@ sidebar_position: 2
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -35,7 +35,7 @@ Hello, Typst!
 
 **提示:** 你可以使用 `#import "config.typ": *` 或 `#include "content.typ"` 等 Typst 语法来实现 Touying 的多文件架构。
 
-**警告:** `#let (slide,) = utils.slides(s)` 里的逗号对于解包语法来说是必要的！
+**警告:** `#let (slide,) = utils.slides(store)` 里的逗号对于解包语法来说是必要的！
 
 ## 更复杂的例子
 
@@ -53,11 +53,11 @@ Hello, Typst!
 // Register university theme
 // You can remove the theme registration or replace other themes
 // it can still work normally
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 
 // Global information configuration
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
@@ -67,7 +67,7 @@ Hello, Typst!
 
 // Pdfpc configuration
 // typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),
@@ -84,13 +84,13 @@ Hello, Typst!
 ))
 
 // Extract methods
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
 // Extract slide functions
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Animation
@@ -220,8 +220,8 @@ Hello, Typst!
 
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 == Appendix
 
@@ -235,7 +235,7 @@ Hello, Typst!
 Touying 提供了很多内置的主题，能够简单地编写精美的 slides，例如此处的
 
 ```
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 ```
 
 可以使用 university 主题。关于主题更详细的教程，您可以参阅后面的章节。

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/themes/dewdrop.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/themes/dewdrop.md
@@ -17,28 +17,28 @@ sidebar_position: 3
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(
-  s,
+#let store = themes.dewdrop.register(
+  store,
   aspect-ratio: "16-9",
   footer: [Dewdrop],
   navigation: "mini-slides",
   // navigation: "sidebar",
   // navigation: none,
 )
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -64,8 +64,8 @@ sidebar_position: 3
 Dewdrop 默认使用了
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   neutral-darkest: rgb("#000000"),
   neutral-dark: rgb("#202020"),
   neutral-light: rgb("#f3f3f3"),
@@ -74,7 +74,7 @@ Dewdrop 默认使用了
 )
 ```
 
-颜色主题，你可以通过 `#let s = (s.methods.colors)(self: s, ..)` 对其进行修改。
+颜色主题，你可以通过 `#let store = (store.methods.colors)(self: store, ..)` 对其进行修改。
 
 ## slide 函数族
 
@@ -153,21 +153,21 @@ PS: 其中 outline title 可以通过 `#(s.outline-title = [Outline])` 的方式
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(s, aspect-ratio: "16-9", footer: [Dewdrop])
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.dewdrop.register(store, aspect-ratio: "16-9", footer: [Dewdrop])
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -189,27 +189,27 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(
-  s,
+#let store = themes.dewdrop.register(
+  store,
   aspect-ratio: "16-9",
   footer: [Dewdrop],
   navigation: "mini-slides",
   // navigation: none,
 )
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Section A
@@ -255,8 +255,8 @@ Hello, Typst!
 ]
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 = Appendix
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/themes/metropolis.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/themes/metropolis.md
@@ -19,21 +19,21 @@ sidebar_position: 2
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -52,8 +52,8 @@ sidebar_position: 2
 Metropolis 默认使用了
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   neutral-lightest: rgb("#fafafa"),
   primary-dark: rgb("#23373b"),
   secondary-light: rgb("#eb811b"),
@@ -61,7 +61,7 @@ Metropolis 默认使用了
 )
 ```
 
-颜色主题，你可以通过 `#let s = (s.methods.colors)(self: s, ..)` 对其进行修改。
+颜色主题，你可以通过 `#let store = (store.methods.colors)(self: store, ..)` 对其进行修改。
 
 ## slide 函数族
 
@@ -124,17 +124,17 @@ PS: 其中 outline title 可以通过 `#(s.outline-title = [Outline])` 的方式
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slide, slides, title-slide, new-section-slide, focus-slide, touying-outline, alert) = utils.methods(s)
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slide, slides, title-slide, new-section-slide, focus-slide, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
@@ -160,16 +160,16 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #set text(font: "Fira Sans", weight: "light", size: 20pt)
@@ -178,7 +178,7 @@ Hello, Typst!
 #set par(justify: true)
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -214,8 +214,8 @@ Hello, Typst!
 ]
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 = Appendix
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/themes/simple.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/themes/simple.md
@@ -18,12 +18,12 @@ sidebar_position: 1
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -96,12 +96,12 @@ simple 主题提供了一系列自定义 slide 函数：
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -123,11 +123,11 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 #title-slide[

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/themes/university.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/themes/university.md
@@ -15,19 +15,19 @@ sidebar_position: 4
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -43,15 +43,15 @@ sidebar_position: 4
 University 默认使用了
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   primary: rgb("#04364A"),
   secondary: rgb("#176B87"),
   tertiary: rgb("#448C95"),
 )
 ```
 
-颜色主题，你可以通过 `#let s = (s.methods.colors)(self: s, ..)` 对其进行修改。
+颜色主题，你可以通过 `#let store = (store.methods.colors)(self: store, ..)` 对其进行修改。
 
 ## slide 函数族
 
@@ -116,19 +116,19 @@ University 主题提供了一系列自定义 slide 函数：
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -150,19 +150,19 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides.with(title-slide: false)
 
 #title-slide(authors: ([Author A], [Author B]))

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/build-your-own-theme.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/build-your-own-theme.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 使用 Touying 创建一个自己的主题是一件略显复杂的事情，因为我们引入了许多的概念。不过请放心，如果您真的用 Touying 创建了一个自己的主题，也许您就可以深切地感受到 Touying 提供的便利的功能的和强大的可定制性。您可以参考 [主题的源代码](https://github.com/touying-typ/touying/tree/main/themes)，主要需要实现的就是：
 
-- 自定义 `register` 函数，初始化全局单例 `s`；
+- 自定义 `register` 函数，初始化全局单例 `store`；
 - 自定义 `init` 方法；
 - 自定义颜色主题，即修改 `self.colors` 成员变量；
 - 自定义 `alert` 方法，可选；
@@ -72,13 +72,13 @@ sidebar_position: 10
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9")
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = bamboo.register(store, aspect-ratio: "16-9")
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -94,9 +94,9 @@ sidebar_position: 10
 
 除此之外，我们还注册了一个 `self.methods.init` 方法，它可以用来进行一些全局的样式设置，例如在此处，我们加上了 `set text(size: 20pt)` 来设置文字大小。你也可以在这里放置一些额外的全局样式设置，例如 `set par(justify: true)` 等。由于 `init` 函数被放置到了 `self.methods` 里，是一个方法，而非普通函数，因此我们需要加上 `self: none` 参数才能正常使用。
 
-如您所见，后续在 `main.typ` 中，我们会通过 `#show: init` 来应用 `init` 方法里面的全局样式设置，其中 `init` 函数是通过 `utils.methods(s)` 绑定并解包而来的。
+如您所见，后续在 `main.typ` 中，我们会通过 `#show: init` 来应用 `init` 方法里面的全局样式设置，其中 `init` 函数是通过 `utils.methods(store)` 绑定并解包而来的。
 
-如果您多加注意，您会发现 `register` 函数最后有一行独立的 `self`，这其实是代表了将修改后的 `self` 作为返回值返回，后续会被保存在 `#let s = ..` 中，因此这一行是不可或缺的。
+如果您多加注意，您会发现 `register` 函数最后有一行独立的 `self`，这其实是代表了将修改后的 `self` 作为返回值返回，后续会被保存在 `#let store = ..` 中，因此这一行是不可或缺的。
 
 
 ## 颜色主题
@@ -135,10 +135,10 @@ sidebar_position: 10
 并且有一点值得注意，用户可以随时在 `main.typ` 里通过
 
 ```typst
-#let s = (s.methods.colors)(self: s, primary: rgb("#3578B9"))
+#let store = (store.methods.colors)(self: store, primary: rgb("#3578B9"))
 ```
 
-这样的方式修改主题色，其中这句语句需要放在 `register(s)` 之后，以及 `utils.methods(s)` 之前。
+这样的方式修改主题色，其中这句语句需要放在 `register(s)` 之后，以及 `utils.methods(store)` 之前。
 
 这种随时更换颜色主题的内容，正是 Touying 强大可定制性的体现。
 
@@ -241,13 +241,13 @@ self.methods.alert = (self: none, it) => text(fill: self.colors.primary, it)
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = bamboo.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -396,21 +396,21 @@ self.methods.alert = (self: none, it) => text(fill: self.colors.primary, it)
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = bamboo.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = First Section

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/code-styles.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/code-styles.md
@@ -11,11 +11,11 @@ sidebar_position: 4
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -38,18 +38,18 @@ PS：我们可以使用 `#slides-end` 记号来标志 `#show: slides` 的结束�
 
 ## 块风格
 
-很多时候，仅仅使用简单风格并不能实现我们需要的所有功能，为了更强大的功能和更清晰的结构，我们同样可以使用 `#slide[...]` 形式的块风格，其中 `#slide` 函数需要使用 `#let (slide,) = utils.slides(s)` 语法进行解包，才能正常在 `#show: slides` 后使用。
+很多时候，仅仅使用简单风格并不能实现我们需要的所有功能，为了更强大的功能和更清晰的结构，我们同样可以使用 `#slide[...]` 形式的块风格，其中 `#slide` 函数需要使用 `#let (slide,) = utils.slides(store)` 语法进行解包，才能正常在 `#show: slides` 后使用。
 
 例如上面的例子就可以改造成
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -75,19 +75,19 @@ PS：我们可以使用 `#slides-end` 记号来标志 `#show: slides` 的结束�
 
 ## 约定优于配置
 
-你可能注意到了，在使用 simple 主题时，我们使用一级标题会自动创建一个 section slide，这是因为 simple 主题注册了一个 `s.methods.touying-new-section-slide` 方法，因此 touying 会默认调用这个方法。
+你可能注意到了，在使用 simple 主题时，我们使用一级标题会自动创建一个 section slide，这是因为 simple 主题注册了一个 `store.methods.touying-new-section-slide` 方法，因此 touying 会默认调用这个方法。
 
 如果我们不希望它自动创建这样一个 section slide，我们可以将这个方法删除：
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#(s.methods.touying-new-section-slide = none)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#(store.methods.touying-new-section-slide = none)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -110,19 +110,19 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#(s.methods.touying-new-section-slide = (self: none, section, ..args) => {
+#let store = themes.simple.register(store)
+#(store.methods.touying-new-section-slide = (self: none, section, ..args) => {
   self = utils.empty-page(self)
-  (s.methods.touying-slide)(self: self, section: section, {
+  (store.methods.touying-slide)(self: self, section: section, {
     set align(center + horizon)
     set text(size: 2em, fill: s.colors.primary, style: "italic", weight: "bold")
     section
   }, ..args)
 })
-#let (init, slides, touying-outline) = utils.methods(s)
+#let (init, slides, touying-outline) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -138,21 +138,21 @@ Hello, Typst!
 
 ![image](https://github.com/touying-typ/touying/assets/34951714/5305efda-0cd4-42eb-9f2e-89abc30b6ca2)
 
-同样地，我们也可以修改 `s.methods.touying-new-subsection-slide` 来对 `subsection` 做同样的事。
+同样地，我们也可以修改 `store.methods.touying-new-subsection-slide` 来对 `subsection` 做同样的事。
 
-实际上，除了 `s.methods.touying-new-section-slide`，另一个特殊的 `slide` 函数就是 `s.methods.slide` 函数，它会在简单风格里没有显示使用 `#slide[...]` 的情况下默认被调用。
+实际上，除了 `store.methods.touying-new-section-slide`，另一个特殊的 `slide` 函数就是 `store.methods.slide` 函数，它会在简单风格里没有显示使用 `#slide[...]` 的情况下默认被调用。
 
 同时，由于 `#slide[...]` 被注册在了 `s.slides = ("slide",)` 里，因此 `section`，`subsection` 和 `title` 参数会被自动传入，而其他的如 `#focus-slide[...]` 则不会自动传入这三个参数。
 
 :::tip[原理]
 
-实际上，你也可以不使用 `#show: slides` 和 `utils.slides(s)`，而是只使用 `utils.methods(s)`，例如
+实际上，你也可以不使用 `#show: slides` 和 `utils.slides(store)`，而是只使用 `utils.methods(store)`，例如
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, touying-outline, slide) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, touying-outline, slide) = utils.methods(store)
 #show: init
 
 #slide(section: [Title], title: [First Slide])[

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/dynamic/cover.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/dynamic/cover.md
@@ -9,7 +9,7 @@ sidebar_position: 4
 
 ## 默认 Cover 函数：`hide`
 
-`cover` 函数是保存在 `s.methods.cover` 的一个方法，后续 `uncover` 和 `#pause` 均会在这里取出 `cover` 函数来使用。
+`cover` 函数是保存在 `store.methods.cover` 的一个方法，后续 `uncover` 和 `#pause` 均会在这里取出 `cover` 函数来使用。
 
 默认的 `cover` 函数是 [hide](https://typst.app/docs/reference/layout/hide/) 函数，这个函数能将内部的内容更改为不可见的，且不会影响布局。
 
@@ -19,7 +19,7 @@ sidebar_position: 4
 有的情况下，您想用您自己的 `cover` 函数，那么您可以通过
 
 ```typst
-let s = (s.methods.update-cover)(self: s, is-method: true, cover-fn)
+#let store = (store.methods.update-cover)(self: store, is-method: true, cover-fn)
 ```
 
 方法来设置您自己的 `cover` 函数，其中如果设置 `is-method: false`，则 Touying 会帮您将 `cover-fn` 包装成一个方法。
@@ -30,7 +30,7 @@ let s = (s.methods.update-cover)(self: s, is-method: true, cover-fn)
 Touying 提供了半透明 Cover 函数的支持，只需要加入
 
 ```typst
-#let s = (s.methods.enable-transparent-cover)(self: s)
+#let store = (store.methods.enable-transparent-cover)(self: store)
 ```
 
 即可开启，其中你可以通过 `alpha: ..` 参数调节透明度。
@@ -48,7 +48,7 @@ Touying 提供了半透明 Cover 函数的支持，只需要加入
 `enable-transparent-cover` 方法定义为
 
 ```typst
-#let s.methods.enable-transparent-cover = (
+#let store.methods.enable-transparent-cover = (
   self: none,
   constructor: rgb,
   alpha: 85%,

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/dynamic/handout.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/dynamic/handout.md
@@ -11,5 +11,5 @@ sidebar_position: 6
 开启讲义模式是很简单的：
 
 ```typst
-#let s = (s.methods.enable-handout-mode)(self: s)
+#let store = (store.methods.enable-handout-mode)(self: store)
 ```

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/dynamic/other.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/dynamic/other.md
@@ -18,11 +18,11 @@ Touying 还提供了 `touying-reducer`，它能为 cetz 与 fletcher 加入 `pau
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/external/pdfpc.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/external/pdfpc.md
@@ -21,7 +21,7 @@ Touying 与 [Polylux](https://polylux.dev/book/external/pdfpc.html) 保持一致
 为了加入 pdfpc 配置，你可以使用
 
 ```typst
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/global-settings.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/global-settings.md
@@ -21,8 +21,8 @@ self.methods.init = (self: none, body) => {
 如果你并非一个主题制作者，而只是想给你的 slides 添加一些自己的全局样式，你可以简单地将它们放在 `#show: init` 之后，以及 `#show: slides` 之前，例如 metropolis 主题就推荐你自行加入以下全局样式：
 
 ```typst
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9")
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9")
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 // global styles
@@ -32,7 +32,7 @@ self.methods.init = (self: none, body) => {
 #set par(justify: true)
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -57,8 +57,8 @@ self.methods.init = (self: none, body) => {
 你可以通过
 
 ```typst
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
@@ -69,12 +69,12 @@ self.methods.init = (self: none, body) => {
 
 分别设置 slides 的标题、副标题、作者、日期和机构信息。在后续，你就可以通过 `s.info` 或 `self.info` 这样的方式访问它们。
 
-这些信息一般会在主题的 `title-slide`、`header` 和 `footer` 被使用到，例如 `#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)`。
+这些信息一般会在主题的 `title-slide`、`header` 和 `footer` 被使用到，例如 `#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)`。
 
 其中 `date` 可以接收 `datetime` 格式和 `content` 格式，并且 `datetime` 格式的日期显示格式，可以通过
 
 ```typst
-#let s = (s.methods.datetime-format)(self: s, "[year]-[month]-[day]")
+#let store = (store.methods.datetime-format)(self: store, "[year]-[month]-[day]")
 ```
 
 的方式更改。
@@ -85,10 +85,10 @@ self.methods.init = (self: none, body) => {
 
 您应该知道，Typst 是一个支持增量渲染的排版语言，也就是说，Typst 会缓存之前的函数调用结果，这就要求 Typst 里只有纯函数，即无法改变外部变量的函数。因此我们很难真正意义上地像 LaTeX 那样修改一个全局变量。即使是使用 `state` 或 `counter`，也需要使用 `locate` 与回调函数来获取里面的值，且实际上这种方式会对性能有很大的影响。
 
-Touying 并没有使用 `state` 和 `counter`，也没有违反 Typst 纯函数的原则，而是使用了一种巧妙的方式，并以面向对象风格的代码，维护了一个全局单例 `s`。在 Touying 中，一个对象指拥有自己的成员变量和方法的 Typst 字典，并且我们约定方法均有一个命名参数 `self` 用于传入对象自身，并且方法均放在 `.methods` 域里。有了这个理念，我们就不难写出更新 `info` 的方法了：
+Touying 并没有使用 `state` 和 `counter`，也没有违反 Typst 纯函数的原则，而是使用了一种巧妙的方式，并以面向对象风格的代码，维护了一个全局单例 `store`。在 Touying 中，一个对象指拥有自己的成员变量和方法的 Typst 字典，并且我们约定方法均有一个命名参数 `self` 用于传入对象自身，并且方法均放在 `.methods` 域里。有了这个理念，我们就不难写出更新 `info` 的方法了：
 
 ```
-#let s = (
+#let store = (
   info: (:),
   methods: (
     // update info
@@ -99,39 +99,39 @@ Touying 并没有使用 `state` 和 `counter`，也没有违反 Typst 纯函数�
   )
 )
 
-#let s = (s.methods.info)(self: s, title: [title])
+#let store = (store.methods.info)(self: store, title: [title])
 
 Title is #s.info.title
 ```
 
-这样，你也能够理解 `utils.methods()` 函数的用途了：将 `self` 绑定到 `s` 的所有方法上并返回，并通过解包语法简化后续的使用。
+这样，你也能够理解 `utils.methods()` 函数的用途了：将 `self` 绑定到 `store` 的所有方法上并返回，并通过解包语法简化后续的使用。
 
 ```typst
-#let (init, slides, alert) = utils.methods(s)
+#let (init, slides, alert) = utils.methods(store)
 ```
 :::
 
 
 ## 状态初始化
 
-一般而言，上面的两种方式就已经足够用于加入全局设置了，但是仍然会有部分情况，我们需要初始化 counters 或 states。如果将这些代码放在 `#show: slides` 之前，就会创建一个空白页，这是我们不想看见的，因此这时候我们就可以使用 `s.methods.append-preamble` 方法。例如在使用 codly 包的时候：
+一般而言，上面的两种方式就已经足够用于加入全局设置了，但是仍然会有部分情况，我们需要初始化 counters 或 states。如果将这些代码放在 `#show: slides` 之前，就会创建一个空白页，这是我们不想看见的，因此这时候我们就可以使用 `store.methods.append-preamble` 方法。例如在使用 codly 包的时候：
 
 ```typst
 #import "@preview/touying:0.3.1": *
 #import "@preview/codly:0.2.0": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.append-preamble)(self: s)[
+#let store = themes.simple.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.append-preamble)(self: store)[
   #codly(languages: (
     rust: (name: "Rust", icon: "\u{fa53}", color: rgb("#CE412B")),
   ))
 ]
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show heading.where(level: 2): set block(below: 1em)
 #show: init
 #show: codly-init.with()
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 #slide[
@@ -152,7 +152,7 @@ Title is #s.info.title
 ```typst
 // Pdfpc configuration
 // typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/integration/cetz.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/integration/cetz.md
@@ -18,11 +18,11 @@ Touying 提供了 `touying-reducer`，它能为 cetz 与 fletcher 加入 `pause`
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/integration/codly.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/integration/codly.md
@@ -4,24 +4,24 @@ sidebar_position: 5
 
 # Codly
 
-在使用 codly 的时候，我们应该使用 `s.methods.append-preamble` 方法进行初始化。
+在使用 codly 的时候，我们应该使用 `store.methods.append-preamble` 方法进行初始化。
 
 ```typst
 #import "@preview/touying:0.3.1": *
 #import "@preview/codly:0.2.0": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.append-preamble)(self: s)[
+#let store = themes.simple.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.append-preamble)(self: store)[
   #codly(languages: (
     rust: (name: "Rust", icon: "\u{fa53}", color: rgb("#CE412B")),
   ))
 ]
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show heading.where(level: 2): set block(below: 1em)
 #show: init
 #show: codly-init.with()
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 #slide[

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/integration/fletcher.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/integration/fletcher.md
@@ -16,11 +16,11 @@ Touying 提供了 `touying-reducer`，它能为 fletcher 加入 `pause` 和 `mea
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/integration/pinit.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/integration/pinit.md
@@ -40,7 +40,7 @@ A simple #pin(1)highlighted text#pin(2).
 #import "@preview/pinit:0.1.3": *
 
 #(s.page-args.paper = "presentation-4-3")
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show: init
 
 #set text(size: 20pt, font: "Calibri", ligatures: false)
@@ -60,7 +60,7 @@ A simple #pin(1)highlighted text#pin(2).
   body
 }
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 // Main body

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/layout.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/layout.md
@@ -112,11 +112,11 @@ sidebar_position: 5
 #(s.page-args.footer = [Custom Footer])
 ```
 
-这样方式进行更换。不过需要注意的是，如果这样更换了页面参数，你需要将其放在 `#let (slide,) = utils.slides(s)` 之前，否则就需要重新调用 `#let (slide,) = utils.slides(s)`。
+这样方式进行更换。不过需要注意的是，如果这样更换了页面参数，你需要将其放在 `#let (slide,) = utils.slides(store)` 之前，否则就需要重新调用 `#let (slide,) = utils.slides(store)`。
 
 :::warning[警告]
 
-因此，你不应该自己使用 `set page(..)` 命令，而是应该修改 `s` 内部的 `s.page-args` 成员变量。
+因此，你不应该自己使用 `set page(..)` 命令，而是应该修改 `store` 内部的 `s.page-args` 成员变量。
 
 :::
 
@@ -132,7 +132,7 @@ sidebar_position: 5
 #import "@preview/touying:0.3.1": *
 #import "@preview/octique:0.1.0": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9")
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9")
 #(s.page-args.header = self => {
   // display the original header
   utils.call-or-display(self, s.page-args.header)
@@ -141,7 +141,7 @@ sidebar_position: 5
     #octique("mark-github", color: rgb("#fafafa"), width: 1.5em, height: 1.5em)
   ]
 })
-#let (init, slide) = utils.methods(s)
+#let (init, slide) = utils.methods(store)
 #show: init
 
 #slide(title: [Title])[

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/progress/counters.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/progress/counters.md
@@ -35,8 +35,8 @@ Touying 的状态均放置于 `states` 命名空间下，包括所有的计数�
 
 ```typst
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.methods(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.methods(store)
 
 #slide[
   appendix
@@ -45,4 +45,4 @@ Touying 的状态均放置于 `states` 命名空间下，包括所有的计数�
 
 语法进入后记。
 
-并且 `#let s = (s.methods.appendix-in-outline)(self: s, false)` 可以让后记的 section 不显示在大纲中。
+并且 `#let store = (store.methods.appendix-in-outline)(self: store, false)` 可以让后记的 section 不显示在大纲中。

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/sections.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/sections.md
@@ -13,11 +13,11 @@ sidebar_position: 3
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.dewdrop.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Section
@@ -36,11 +36,11 @@ Hello, Touying!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.university.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Section
@@ -62,10 +62,10 @@ Hello, Touying!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let (init, slides, alert, touying-outline) = utils.methods(s)
+#let (init, slides, alert, touying-outline) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(slide-level: 2)
 
 = Section

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/start.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/start.md
@@ -11,11 +11,11 @@ sidebar_position: 2
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -35,7 +35,7 @@ Hello, Typst!
 
 **提示:** 你可以使用 `#import "config.typ": *` 或 `#include "content.typ"` 等 Typst 语法来实现 Touying 的多文件架构。
 
-**警告:** `#let (slide,) = utils.slides(s)` 里的逗号对于解包语法来说是必要的！
+**警告:** `#let (slide,) = utils.slides(store)` 里的逗号对于解包语法来说是必要的！
 
 ## 更复杂的例子
 
@@ -53,11 +53,11 @@ Hello, Typst!
 // Register university theme
 // You can remove the theme registration or replace other themes
 // it can still work normally
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 
 // Global information configuration
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
@@ -67,7 +67,7 @@ Hello, Typst!
 
 // Pdfpc configuration
 // typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),
@@ -84,13 +84,13 @@ Hello, Typst!
 ))
 
 // Extract methods
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
 // Extract slide functions
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Animation
@@ -220,8 +220,8 @@ Hello, Typst!
 
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 == Appendix
 
@@ -235,7 +235,7 @@ Hello, Typst!
 Touying 提供了很多内置的主题，能够简单地编写精美的 slides，例如此处的
 
 ```
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 ```
 
 可以使用 university 主题。关于主题更详细的教程，您可以参阅后面的章节。

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/themes/dewdrop.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/themes/dewdrop.md
@@ -17,28 +17,28 @@ sidebar_position: 3
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(
-  s,
+#let store = themes.dewdrop.register(
+  store,
   aspect-ratio: "16-9",
   footer: [Dewdrop],
   navigation: "mini-slides",
   // navigation: "sidebar",
   // navigation: none,
 )
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -64,8 +64,8 @@ sidebar_position: 3
 Dewdrop 默认使用了
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   neutral-darkest: rgb("#000000"),
   neutral-dark: rgb("#202020"),
   neutral-light: rgb("#f3f3f3"),
@@ -74,7 +74,7 @@ Dewdrop 默认使用了
 )
 ```
 
-颜色主题，你可以通过 `#let s = (s.methods.colors)(self: s, ..)` 对其进行修改。
+颜色主题，你可以通过 `#let store = (store.methods.colors)(self: store, ..)` 对其进行修改。
 
 ## slide 函数族
 
@@ -153,21 +153,21 @@ PS: 其中 outline title 可以通过 `#(s.outline-title = [Outline])` 的方式
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(s, aspect-ratio: "16-9", footer: [Dewdrop])
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.dewdrop.register(store, aspect-ratio: "16-9", footer: [Dewdrop])
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -189,27 +189,27 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(
-  s,
+#let store = themes.dewdrop.register(
+  store,
   aspect-ratio: "16-9",
   footer: [Dewdrop],
   navigation: "mini-slides",
   // navigation: none,
 )
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Section A
@@ -255,8 +255,8 @@ Hello, Typst!
 ]
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 = Appendix
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/themes/metropolis.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/themes/metropolis.md
@@ -19,21 +19,21 @@ sidebar_position: 2
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -52,8 +52,8 @@ sidebar_position: 2
 Metropolis 默认使用了
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   neutral-lightest: rgb("#fafafa"),
   primary-dark: rgb("#23373b"),
   secondary-light: rgb("#eb811b"),
@@ -61,7 +61,7 @@ Metropolis 默认使用了
 )
 ```
 
-颜色主题，你可以通过 `#let s = (s.methods.colors)(self: s, ..)` 对其进行修改。
+颜色主题，你可以通过 `#let store = (store.methods.colors)(self: store, ..)` 对其进行修改。
 
 ## slide 函数族
 
@@ -124,17 +124,17 @@ PS: 其中 outline title 可以通过 `#(s.outline-title = [Outline])` 的方式
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slide, slides, title-slide, new-section-slide, focus-slide, touying-outline, alert) = utils.methods(s)
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slide, slides, title-slide, new-section-slide, focus-slide, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
@@ -160,16 +160,16 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #set text(font: "Fira Sans", weight: "light", size: 20pt)
@@ -178,7 +178,7 @@ Hello, Typst!
 #set par(justify: true)
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -214,8 +214,8 @@ Hello, Typst!
 ]
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 = Appendix
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/themes/simple.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/themes/simple.md
@@ -18,12 +18,12 @@ sidebar_position: 1
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -96,12 +96,12 @@ simple 主题提供了一系列自定义 slide 函数：
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -123,11 +123,11 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 #title-slide[

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/themes/university.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/themes/university.md
@@ -15,19 +15,19 @@ sidebar_position: 4
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -43,15 +43,15 @@ sidebar_position: 4
 University 默认使用了
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   primary: rgb("#04364A"),
   secondary: rgb("#176B87"),
   tertiary: rgb("#448C95"),
 )
 ```
 
-颜色主题，你可以通过 `#let s = (s.methods.colors)(self: s, ..)` 对其进行修改。
+颜色主题，你可以通过 `#let store = (store.methods.colors)(self: store, ..)` 对其进行修改。
 
 ## slide 函数族
 
@@ -116,19 +116,19 @@ University 主题提供了一系列自定义 slide 函数：
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -150,19 +150,19 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides.with(title-slide: false)
 
 #title-slide(authors: ([Author A], [Author B]))

--- a/docs/versioned_docs/version-0.3.x/build-your-own-theme.md
+++ b/docs/versioned_docs/version-0.3.x/build-your-own-theme.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 Creating your own theme with Touying might seem a bit complex initially due to the introduction of various concepts. However, fear not; if you successfully create a custom theme with Touying, you'll likely experience the convenience and powerful customization features it offers. You can refer to the [source code of existing themes](https://github.com/touying-typ/touying/tree/main/themes) for guidance. The key steps to implement are:
 
-- Customize the `register` function to initialize the global singleton `s`.
+- Customize the `register` function to initialize the global singleton `store`.
 - Customize the `init` method.
 - Define a color theme by modifying the `self.colors` member variable.
 - Customize the `alert` method (optional).
@@ -71,13 +71,13 @@ Generally, the first step in creating slides is to determine font size and page 
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9")
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = bamboo.register(store, aspect-ratio: "16-9")
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -93,9 +93,9 @@ As you can see, we created a `register` function and passed an `aspect-ratio` pa
 
 In addition, we registered a `self.methods.init` method, which can be used for some global style settings. For example, in this case, we added `set text(size: 20pt)` to set the font size. You can also place additional global style settings here, such as `set par(justify: true)`. Since the `init` function is placed inside `self.methods`, it is a method, not a regular function. Therefore, we need to add the parameter `self: none` to use it properly.
 
-As you can see, later in `main.typ`, we apply the global style settings in `init` using `#show: init`, where `init` is bound and unpacked through `utils.methods(s)`.
+As you can see, later in `main.typ`, we apply the global style settings in `init` using `#show: init`, where `init` is bound and unpacked through `utils.methods(store)`.
 
-If you pay extra attention, you'll notice that the `register` function has an independent `self` at the end. This actually represents returning the modified `self` as the return value, which will be saved in `#let s = ..`. This line is therefore indispensable.
+If you pay extra attention, you'll notice that the `register` function has an independent `self` at the end. This actually represents returning the modified `self` as the return value, which will be saved in `#let store = ..`. This line is therefore indispensable.
 
 ## Color Theme
 
@@ -133,7 +133,7 @@ After adding the color theme, we can access the color using syntax like `self.co
 It's worth noting that users can change the theme color at any time using:
 
 ```typst
-#let s = (s.methods.colors)(self: s, primary: rgb("#3578B9"))
+#let store = (store.methods.colors)(self: store, primary: rgb("#3578B9"))
 ```
 
 This flexibility demonstrates Touying's powerful customization capabilities.
@@ -233,13 +233,13 @@ We also need to customize a `slide` method that accepts `slide(self: none, title
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = bamboo.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -389,21 +389,21 @@ Finally, we update the `slides(self: none, title-slide: true, slide-level: 1, ..
 #import "@preview/touying:0.3.1": *
 #import "bamboo.typ"
 
-#let s = bamboo.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = bamboo.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = First Section

--- a/docs/versioned_docs/version-0.3.x/code-styles.md
+++ b/docs/versioned_docs/version-0.3.x/code-styles.md
@@ -11,11 +11,11 @@ If we only need simplicity, we can directly input content under the heading, jus
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -37,18 +37,18 @@ PS: We can use the `#slides-end` marker to signify the end of `#show: slides`.
 
 ## Block Style
 
-Many times, using simple style alone cannot achieve all the functions we need. For more powerful features and clearer structure, we can also use block style in the form of `#slide[...]`. The `#slide` function needs to be unpacked using the syntax `#let (slide,) = utils.slides(s)` to be used correctly after `#show: slides`.
+Many times, using simple style alone cannot achieve all the functions we need. For more powerful features and clearer structure, we can also use block style in the form of `#slide[...]`. The `#slide` function needs to be unpacked using the syntax `#let (slide,) = utils.slides(store)` to be used correctly after `#show: slides`.
 
 For example, the previous example can be transformed into:
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -73,19 +73,19 @@ There are many advantages to doing this:
 
 ## Convention Over Configuration
 
-You may have noticed that when using the simple theme, using a level-one heading automatically creates a new section slide. This is because the simple theme registers an `s.methods.touying-new-section-slide` method, so Touying will automatically call this method.
+You may have noticed that when using the simple theme, using a level-one heading automatically creates a new section slide. This is because the simple theme registers an `store.methods.touying-new-section-slide` method, so Touying will automatically call this method.
 
 If we don't want it to automatically create such a section slide, we can delete this method:
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#(s.methods.touying-new-section-slide = none)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#(store.methods.touying-new-section-slide = none)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -108,19 +108,19 @@ Similarly, we can register a new section slide:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#(s.methods.touying-new-section-slide = (self: none, section, ..args) => {
+#let store = themes.simple.register(store)
+#(store.methods.touying-new-section-slide = (self: none, section, ..args) => {
   self = utils.empty-page(self)
-  (s.methods.touying-slide)(self: self, section: section, {
+  (store.methods.touying-slide)(self: self, section: section, {
     set align(center + horizon)
     set text(size: 2em, fill: s.colors.primary, style: "italic", weight: "bold")
     section
   }, ..args)
 })
-#let (init, slides, touying-outline) = utils.methods(s)
+#let (init, slides, touying-outline) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -136,21 +136,21 @@ Hello, Typst!
 
 ![image](https://github.com/touying-typ/touying/assets/34951714/5305efda-0cd4-42eb-9f2e-89abc30b6ca2)
 
-Similarly, we can modify `s.methods.touying-new-subsection-slide` to do the same for `subsection`.
+Similarly, we can modify `store.methods.touying-new-subsection-slide` to do the same for `subsection`.
 
-In fact, besides `s.methods.touying-new-section-slide`, another special `slide` function is the `s.methods.slide` function, which will be called by default in simple style when `#slide[...]` is not explicitly used.
+In fact, besides `store.methods.touying-new-section-slide`, another special `slide` function is the `store.methods.slide` function, which will be called by default in simple style when `#slide[...]` is not explicitly used.
 
 Also, since `#slide[...]` is registered in `s.slides = ("slide",)`, the `section`, `subsection`, and `title` parameters will be automatically passed, while others like `#focus-slide[...]` will not automatically receive these three parameters.
 
 :::tip[Principle]
 
-In fact, you can also not use `#show: slides` and `utils.slides(s)`, but only use `utils.methods(s)`, for example:
+In fact, you can also not use `#show: slides` and `utils.slides(store)`, but only use `utils.methods(store)`, for example:
 
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, touying-outline, slide) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, touying-outline, slide) = utils.methods(store)
 #show: init
 
 #slide(section: [Title], title: [First Slide])[

--- a/docs/versioned_docs/version-0.3.x/dynamic/cover.md
+++ b/docs/versioned_docs/version-0.3.x/dynamic/cover.md
@@ -8,7 +8,7 @@ As you already know, both `uncover` and `#pause` use the `cover` function to con
 
 ## Default Cover Function: `hide`
 
-The `cover` function is a method stored in `s.methods.cover`, which is later used by `uncover` and `#pause`.
+The `cover` function is a method stored in `store.methods.cover`, which is later used by `uncover` and `#pause`.
 
 The default `cover` function is the [hide](https://typst.app/docs/reference/layout/hide/) function. This function makes the internal content invisible without affecting the layout.
 
@@ -17,7 +17,7 @@ The default `cover` function is the [hide](https://typst.app/docs/reference/layo
 In some cases, you might want to use your own `cover` function. In that case, you can set your own `cover` function using:
 
 ```typst
-let s = (s.methods.update-cover)(self: s, is-method: true, cover-fn)
+#let store = (store.methods.update-cover)(self: store, is-method: true, cover-fn)
 ```
 
 Here, if you set `is-method: false`, Touying will wrap `cover-fn` into a method for you.
@@ -27,7 +27,7 @@ Here, if you set `is-method: false`, Touying will wrap `cover-fn` into a method 
 Touying supports a semi-transparent cover function, which can be enabled by adding:
 
 ```typst
-#let s = (s.methods.enable-transparent-cover)(self: s)
+#let store = (store.methods.enable-transparent-cover)(self: store)
 ```
 
 You can adjust the transparency through the `alpha: ..` parameter.
@@ -43,7 +43,7 @@ Note that the `transparent-cover` here does not preserve text layout like `hide`
 The `enable-transparent-cover` method is defined as:
 
 ```typst
-#let s.methods.enable-transparent-cover = (
+#let store.methods.enable-transparent-cover = (
   self: none,
   constructor: rgb,
   alpha: 85%,

--- a/docs/versioned_docs/version-0.3.x/dynamic/handout.md
+++ b/docs/versioned_docs/version-0.3.x/dynamic/handout.md
@@ -11,5 +11,5 @@ The handout mode differs from the regular mode as it doesn't require intricate a
 Enabling handout mode is simple:
 
 ```typst
-#let s = (s.methods.enable-handout-mode)(self: s)
+#let store = (store.methods.enable-handout-mode)(self: store)
 ```

--- a/docs/versioned_docs/version-0.3.x/dynamic/other.md
+++ b/docs/versioned_docs/version-0.3.x/dynamic/other.md
@@ -18,11 +18,11 @@ Here's an example:
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/versioned_docs/version-0.3.x/external/pdfpc.md
+++ b/docs/versioned_docs/version-0.3.x/external/pdfpc.md
@@ -21,7 +21,7 @@ For example, you can add notes using `#pdfpc.speaker-note("This is a note that o
 To add pdfpc configurations, you can use
 
 ```typst
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),

--- a/docs/versioned_docs/version-0.3.x/global-settings.md
+++ b/docs/versioned_docs/version-0.3.x/global-settings.md
@@ -21,8 +21,8 @@ self.methods.init = (self: none, body) => {
 If you are not a theme creator but want to add your own global styles to your slides, you can simply place them after `#show: init` and before `#show: slides`. For example, the metropolis theme recommends adding the following global styles:
 
 ```typst
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9")
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9")
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 // global styles
@@ -32,7 +32,7 @@ If you are not a theme creator but want to add your own global styles to your sl
 #set par(justify: true)
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -56,8 +56,8 @@ Like Beamer, Touying, through an OOP-style unified API design, can help you bett
 You can set the title, subtitle, author, date, and institution information for slides using:
 
 ```typst
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
@@ -71,13 +71,13 @@ In subsequent slides, you can access them through `s.info` or `self.info`.
 This information is generally used in the title-slide, header, and footer of the theme, for example:
 
 ```typst
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
 ```
 
 The `date` can accept `datetime` format or `content` format, and the display format for the `datetime` format can be changed using:
 
 ```typst
-#let s = (s.methods.datetime-format)(self: s, "[year]-[month]-[day]")
+#let store = (store.methods.datetime-format)(self: store, "[year]-[month]-[day]")
 ```
 
 :::tip[Principle]
@@ -86,10 +86,10 @@ Here, we will introduce a bit of OOP concept in Touying.
 
 You should know that Typst is a typesetting language that supports incremental rendering, which means Typst caches the results of previous function calls. This requires that Typst consists of pure functions, meaning functions that do not change external variables. Thus, it is challenging to modify a global variable in the true sense, even with the use of `state` or `counter`. This would require the use of `locate` with callback functions to obtain the values inside, and this approach would have a significant impact on performance.
 
-Touying does not use `state` or `counter` and does not violate the principle of pure functions in Typst. Instead, it uses a clever approach in an object-oriented style, maintaining a global singleton `s`. In Touying, an object refers to a Typst dictionary with its own member variables and methods. We agree that methods all have a named parameter `self` for passing the object itself, and methods are placed in the `.methods` domain. With this concept, it becomes easier to write methods to update `info`:
+Touying does not use `state` or `counter` and does not violate the principle of pure functions in Typst. Instead, it uses a clever approach in an object-oriented style, maintaining a global singleton `store`. In Touying, an object refers to a Typst dictionary with its own member variables and methods. We agree that methods all have a named parameter `self` for passing the object itself, and methods are placed in the `.methods` domain. With this concept, it becomes easier to write methods to update `info`:
 
 ```typst
-#let s = (
+#let store = (
   info: (:),
   methods: (
     // update info
@@ -100,38 +100,38 @@ Touying does not use `state` or `counter` and does not violate the principle of 
   )
 )
 
-#let s = (s.methods.info)(self: s, title: [title])
+#let store = (store.methods.info)(self: store, title: [title])
 
 Title is #s.info.title
 ```
 
-Now you can understand the purpose of the `utils.methods()` function: to bind `self` to all methods of `s` and return it, simplifying the subsequent usage through unpacking syntax.
+Now you can understand the purpose of the `utils.methods()` function: to bind `self` to all methods of `store` and return it, simplifying the subsequent usage through unpacking syntax.
 
 ```typst
-#let (init, slides, alert) = utils.methods(s)
+#let (init, slides, alert) = utils.methods(store)
 ```
 :::
 
 ## State Initialization
 
-In general, the two ways mentioned above are sufficient for adding global settings. However, there are still situations where we need to initialize counters or states. If you place this code before `#show: slides`, a blank page will be created, which is something we don't want to see. In such cases, you can use the `s.methods.append-preamble` method. For example, when using the codly package:
+In general, the two ways mentioned above are sufficient for adding global settings. However, there are still situations where we need to initialize counters or states. If you place this code before `#show: slides`, a blank page will be created, which is something we don't want to see. In such cases, you can use the `store.methods.append-preamble` method. For example, when using the codly package:
 
 ```typst
 #import "@preview/touying:0.3.1": *
 #import "@preview/codly:0.2.0": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.append-preamble)(self: s)[
+#let store = themes.simple.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.append-preamble)(self: store)[
   #codly(languages: (
     rust: (name: "Rust", icon: "\u{fa53}", color: rgb("#CE412B")),
   ))
 ]
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show heading.where(level: 2): set block(below: 1em)
 #show: init
 #show: codly-init.with()
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 #slide[
@@ -151,7 +151,7 @@ Or when configuring Pdfpc:
 ```typst
 // Pdfpc configuration
 // typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),

--- a/docs/versioned_docs/version-0.3.x/integration/cetz.md
+++ b/docs/versioned_docs/version-0.3.x/integration/cetz.md
@@ -18,11 +18,11 @@ An example:
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/versioned_docs/version-0.3.x/integration/codly.md
+++ b/docs/versioned_docs/version-0.3.x/integration/codly.md
@@ -4,24 +4,24 @@ sidebar_position: 5
 
 # Codly
 
-When using Codly, we should initialize it using the `s.methods.append-preamble` method.
+When using Codly, we should initialize it using the `store.methods.append-preamble` method.
 
 ```typst
 #import "@preview/touying:0.3.1": *
 #import "@preview/codly:0.2.0": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.append-preamble)(self: s)[
+#let store = themes.simple.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.append-preamble)(self: store)[
   #codly(languages: (
     rust: (name: "Rust", icon: "\u{fa53}", color: rgb("#CE412B")),
   ))
 ]
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show heading.where(level: 2): set block(below: 1em)
 #show: init
 #show: codly-init.with()
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 #slide[

--- a/docs/versioned_docs/version-0.3.x/integration/fletcher.md
+++ b/docs/versioned_docs/version-0.3.x/integration/fletcher.md
@@ -16,11 +16,11 @@ An example:
 #let cetz-canvas = touying-reducer.with(reduce: cetz.canvas, cover: cetz.draw.hide.with(bounds: true))
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let (init, slides) = utils.methods(s)
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(title-slide: false, outline-slide: false)
 
 // cetz animation

--- a/docs/versioned_docs/version-0.3.x/integration/pinit.md
+++ b/docs/versioned_docs/version-0.3.x/integration/pinit.md
@@ -38,7 +38,7 @@ An example of shared usage with Touying:
 #import "@preview/pinit:0.1.3": *
 
 #(s.page-args.paper = "presentation-4-3")
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show: init
 
 #set text(size: 20pt, font: "Calibri", ligatures: false)
@@ -58,7 +58,7 @@ An example of shared usage with Touying:
   body
 }
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 // Main body

--- a/docs/versioned_docs/version-0.3.x/layout.md
+++ b/docs/versioned_docs/version-0.3.x/layout.md
@@ -112,7 +112,7 @@ Similarly, if you are not satisfied with the header or footer style of a theme, 
 #(s.page-args.footer = [Custom Footer])
 ```
 
-to replace it. However, please note that if you replace the page parameters in this way, you need to place it before `#let (slide,) = utils.slides(s)`, or you need to call `#let (slide,) = utils.slides(s)` again.
+to replace it. However, please note that if you replace the page parameters in this way, you need to place it before `#let (slide,) = utils.slides(store)`, or you need to call `#let (slide,) = utils.slides(store)` again.
 
 :::warning[Warning]
 
@@ -132,7 +132,7 @@ For example, suppose we decide to add the GitHub icon to the metropolis theme. W
 #import "@preview/touying:0.3.1": *
 #import "@preview/octique:0.1.0": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9")
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9")
 #(s.page-args.header = self => {
   // display the original header
   utils.call-or-display(self, s.page-args.header)
@@ -141,7 +141,7 @@ For example, suppose we decide to add the GitHub icon to the metropolis theme. W
     #octique("mark-github", color: rgb("#fafafa"), width: 1.5em, height: 1.5em)
   ]
 })
-#let (init, slide) = utils.methods(s)
+#let (init, slide) = utils.methods(store)
 #show: init
 
 #slide(title: [Title])[

--- a/docs/versioned_docs/version-0.3.x/progress/counters.md
+++ b/docs/versioned_docs/version-0.3.x/progress/counters.md
@@ -32,8 +32,8 @@ You can use
 
 ```typst
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.methods(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.methods(store)
 
 #slide[
   appendix
@@ -42,4 +42,4 @@ You can use
 
 syntax to enter the appendix.
 
-Additionally, `#let s = (s.methods.appendix-in-outline)(self: s, false)` can be used to hide the appendix section from the outline.
+Additionally, `#let store = (store.methods.appendix-in-outline)(self: store, false)` can be used to hide the appendix section from the outline.

--- a/docs/versioned_docs/version-0.3.x/sections.md
+++ b/docs/versioned_docs/version-0.3.x/sections.md
@@ -13,11 +13,11 @@ Generally, level 1, level 2, and level 3 headings correspond to section, subsect
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.dewdrop.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Section
@@ -36,11 +36,11 @@ However, often we don't need subsections, and we can use level 1 and level 2 hea
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.university.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Section
@@ -61,10 +61,10 @@ Displaying a table of contents in Touying is straightforward:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let (init, slides, alert, touying-outline) = utils.methods(s)
+#let (init, slides, alert, touying-outline) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides.with(slide-level: 2)
 
 = Section

--- a/docs/versioned_docs/version-0.3.x/start.md
+++ b/docs/versioned_docs/version-0.3.x/start.md
@@ -11,11 +11,11 @@ To use Touying, you just need to include the following in your document:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Title
@@ -35,7 +35,7 @@ It's that simple! You've created your first Touying slides. Congratulations! ðŸŽ
 
 **Tip:** You can use Typst syntax like `#import "config.typ": *` or `#include "content.typ"` to implement Touying's multi-file architecture.
 
-**Warning:** The comma in `#let (slide,) = utils.slides(s)` is necessary for the unpacking syntax.
+**Warning:** The comma in `#let (slide,) = utils.slides(store)` is necessary for the unpacking syntax.
 
 ## More Complex Examples
 
@@ -46,7 +46,7 @@ In fact, Touying provides various styles for slide writing. You can also use the
 Touying offers many built-in themes to easily create beautiful slides. For example, in this case:
 
 ```
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 ```
 
 you can use the university theme. For more detailed tutorials on themes, you can refer to the following sections.
@@ -63,11 +63,11 @@ you can use the university theme. For more detailed tutorials on themes, you can
 // Register university theme
 // You can remove the theme registration or replace other themes
 // it can still work normally
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 
 // Global information configuration
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
@@ -77,7 +77,7 @@ you can use the university theme. For more detailed tutorials on themes, you can
 
 // Pdfpc configuration
 // typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),
@@ -94,13 +94,13 @@ you can use the university theme. For more detailed tutorials on themes, you can
 ))
 
 // Extract methods
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
 // Extract slide functions
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Animation
@@ -224,8 +224,8 @@ you can use the university theme. For more detailed tutorials on themes, you can
 
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 == Appendix
 
@@ -239,7 +239,7 @@ you can use the university theme. For more detailed tutorials on themes, you can
 Touying offers many built-in themes to easily create beautiful slides. For example, in this case:
 
 ```
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 ```
 
 you can use the university theme. For more detailed tutorials on themes, you can refer to the following sections.

--- a/docs/versioned_docs/version-0.3.x/themes/dewdrop.md
+++ b/docs/versioned_docs/version-0.3.x/themes/dewdrop.md
@@ -17,28 +17,28 @@ You can initialize it using the following code:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(
-  s,
+#let store = themes.dewdrop.register(
+  store,
   aspect-ratio: "16-9",
   footer: [Dewdrop],
   navigation: "mini-slides",
   // navigation: "sidebar",
   // navigation: none,
 )
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -64,8 +64,8 @@ The Dewdrop theme also provides an `#alert[..]` function, which you can use with
 Dewdrop uses the following default color theme:
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   neutral-darkest: rgb("#000000"),
   neutral-dark: rgb("#202020"),
   neutral-light: rgb("#f3f3f3"),
@@ -74,7 +74,7 @@ Dewdrop uses the following default color theme:
 )
 ```
 
-You can modify this color theme using `#let s = (s.methods.colors)(self: s, ..)`.
+You can modify this color theme using `#let store = (store.methods.colors)(self: store, ..)`.
 
 ## Slide Function Family
 
@@ -153,21 +153,21 @@ PS: You can modify the outline title using `#(s.outline-title = [Outline])`.
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(s, aspect-ratio: "16-9", footer: [Dewdrop])
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.dewdrop.register(store, aspect-ratio: "16-9", footer: [Dewdrop])
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -189,27 +189,27 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.dewdrop.register(
-  s,
+#let store = themes.dewdrop.register(
+  store,
   aspect-ratio: "16-9",
   footer: [Dewdrop],
   navigation: "mini-slides",
   // navigation: none,
 )
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Section A
@@ -255,8 +255,8 @@ Hello, Typst!
 ]
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 = Appendix
 

--- a/docs/versioned_docs/version-0.3.x/themes/metropolis.md
+++ b/docs/versioned_docs/version-0.3.x/themes/metropolis.md
@@ -17,21 +17,21 @@ You can initialize it using the following code:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -50,8 +50,8 @@ The Metropolis theme also provides an `#alert[..]` function, which you can use w
 Metropolis uses the following default color theme:
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   neutral-lightest: rgb("#fafafa"),
   primary-dark: rgb("#23373b"),
   secondary-light: rgb("#eb811b"),
@@ -59,7 +59,7 @@ Metropolis uses the following default color theme:
 )
 ```
 
-You can modify this color theme using `#let s = (s.methods.colors)(self: s, ..)`.
+You can modify this color theme using `#let store = (store.methods.colors)(self: store, ..)`.
 
 ## Slide Function Family
 
@@ -124,17 +124,17 @@ PS: You can modify the outline title using `#(s.outline-title = [Outline])`.
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slide, slides, title-slide, new-section-slide, focus-slide, touying-outline, alert) = utils.methods(s)
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slide, slides, title-slide, new-section-slide, focus-slide, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
@@ -160,16 +160,16 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #set text(font: "Fira Sans", weight: "light", size: 20pt)
@@ -178,7 +178,7 @@ Hello, Typst!
 #set par(justify: true)
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -214,8 +214,8 @@ Hello, Typst!
 ]
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 = Appendix
 

--- a/docs/versioned_docs/version-0.3.x/themes/simple.md
+++ b/docs/versioned_docs/version-0.3.x/themes/simple.md
@@ -17,12 +17,12 @@ You can initialize it using the following code:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -98,12 +98,12 @@ You can set it using `#show: slides.with(..)`.
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -125,11 +125,11 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 #title-slide[

--- a/docs/versioned_docs/version-0.3.x/themes/university.md
+++ b/docs/versioned_docs/version-0.3.x/themes/university.md
@@ -15,19 +15,19 @@ You can initialize the University theme using the following code:
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides
 ```
 
@@ -43,15 +43,15 @@ Additionally, the University theme provides an `#alert[..]` function, which you 
 The University theme defaults to the following color theme:
 
 ```typst
-#let s = (s.methods.colors)(
-  self: s,
+#let store = (store.methods.colors)(
+  self: store,
   primary: rgb("#04364A"),
   secondary: rgb("#176B87"),
   tertiary: rgb("#448C95"),
 )
 ```
 
-You can modify this color theme using `#let s = (s.methods.colors)(self: s, ..)`.
+You can modify this color theme using `#let store = (store.methods.colors)(self: store, ..)`.
 
 ## Slide Function Family
 
@@ -120,19 +120,19 @@ You can set these parameters using `#show: slides.with(..)`.
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides
 
 = Title
@@ -154,19 +154,19 @@ Hello, Typst!
 ```typst
 #import "@preview/touying:0.3.1": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides.with(title-slide: false)
 
 #title-slide(authors: ([Author A], [Author B]))

--- a/examples/aqua-zh.typ
+++ b/examples/aqua-zh.typ
@@ -1,18 +1,18 @@
 #import "../lib.typ": *
 
-#let s = themes.aqua.register(s, aspect-ratio: "16-9", lang: "zh")
+#let store = themes.aqua.register(store, aspect-ratio: "16-9", lang: "zh")
 
-#let s = (s.methods.info)(
-  self: s, 
+#let store = (store.methods.info)(
+  self: store, 
   title: [An Instruction to Typst-Beamer],
   author: [Author],
   date: datetime.today(),
 )
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show: init
 
 #set text(font: "Microsoft YaHei") // "Microsoft YaHei" is recommended.
-#let (slide, title-slide, outline-slide, new-section-slide) = utils.slides(s) 
+#let (slide, title-slide, outline-slide, new-section-slide) = utils.slides(store)
 #show: slides
 
 = 制作一个标题页
@@ -42,7 +42,7 @@
 == Summary
 
 #align(center + horizon)[
-  #set text(size: 3em, weight: "bold", s.colors.primary)
+  #set text(size: 3em, weight: "bold", store.colors.primary)
 
   THANKS FOR ALL
 

--- a/examples/aqua.typ
+++ b/examples/aqua.typ
@@ -1,17 +1,17 @@
 #import "../lib.typ": *
 
-#let s = themes.aqua.register(s, aspect-ratio: "16-9")
+#let store = themes.aqua.register(store, aspect-ratio: "16-9")
 
-#let s = (s.methods.info)(
-  self: s, 
+#let store = (store.methods.info)(
+  self: store, 
   title: [An Instruction to Typst-Beamer],
   author: [Author],
   date: datetime.today(),
 )
-#let (init, slides) = utils.methods(s)
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, outline-slide, new-section-slide) = utils.slides(s) 
+#let (slide, title-slide, outline-slide, new-section-slide) = utils.slides(store) 
 #show: slides
 
 = Title Slide
@@ -36,7 +36,7 @@
 == Summary
 
 #align(center + horizon)[
-  #set text(size: 3em, weight: "bold", s.colors.primary)
+  #set text(size: 3em, weight: "bold", store.colors.primary)
   THANKS FOR ALL
 ]
 

--- a/examples/dewdrop.typ
+++ b/examples/dewdrop.typ
@@ -1,26 +1,26 @@
 #import "../lib.typ": *
 
-#let s = themes.dewdrop.register(
-  s,
+#let store = themes.dewdrop.register(
+  store,
   aspect-ratio: "16-9",
   footer: [Dewdrop],
   navigation: "mini-slides",
   // navigation: none,
 )
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = Section A
@@ -66,8 +66,8 @@
 ]
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 = Appendix
 

--- a/examples/example.typ
+++ b/examples/example.typ
@@ -9,11 +9,11 @@
 // Register university theme
 // You can remove the theme registration or replace other themes
 // it can still work normally
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let store = themes.university.register(store, aspect-ratio: "16-9")
 
 // Global information configuration
-#let s = (s.methods.info)(
-  self: s,
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
@@ -23,7 +23,7 @@
 
 // Pdfpc configuration
 // typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc
-#let s = (s.methods.append-preamble)(self: s, pdfpc.config(
+#let store = (store.methods.append-preamble)(self: store, pdfpc.config(
   duration-minutes: 30,
   start-time: datetime(hour: 14, minute: 10, second: 0),
   end-time: datetime(hour: 14, minute: 40, second: 0),
@@ -40,13 +40,13 @@
 ))
 
 // Extract methods
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
 // Extract slide functions
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Animation
@@ -176,8 +176,8 @@
 
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 == Appendix
 

--- a/examples/metropolis.typ
+++ b/examples/metropolis.typ
@@ -1,15 +1,15 @@
 #import "../lib.typ": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #set text(font: "Fira Sans", weight: "light", size: 20pt)
@@ -18,7 +18,7 @@
 #set par(justify: true)
 #show strong: alert
 
-#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, new-section-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 = First Section
@@ -54,8 +54,8 @@
 ]
 
 // appendix by freezing last-slide-number
-#let s = (s.methods.appendix)(self: s)
-#let (slide,) = utils.slides(s)
+#let store = (store.methods.appendix)(self: store)
+#let (slide,) = utils.slides(store)
 
 = Appendix
 

--- a/examples/simple.typ
+++ b/examples/simple.typ
@@ -1,10 +1,10 @@
 #import "../lib.typ": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-#let (init, slides) = utils.methods(s)
+#let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+#let (init, slides) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(s)
+#let (slide, title-slide, centered-slide, focus-slide) = utils.slides(store)
 #show: slides
 
 #title-slide[

--- a/examples/slides.typ
+++ b/examples/slides.typ
@@ -1,23 +1,23 @@
 #import "../lib.typ": *
 
-// #let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-// #let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: [Custom footer])
-// #let s = themes.dewdrop.register(s, aspect-ratio: "16-9", footer: [Dewdrop])
-#let s = (s.methods.info)(
-  self: s,
+// #let store = themes.simple.register(store, aspect-ratio: "16-9", footer: [Simple slides])
+// #let store = themes.metropolis.register(store, aspect-ratio: "16-9", footer: [Custom footer])
+// #let store = themes.dewdrop.register(store, aspect-ratio: "16-9", footer: [Dewdrop])
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let s = (s.methods.enable-transparent-cover)(self: s)
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let store = (store.methods.enable-transparent-cover)(self: store)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
 #show strong: alert
 
-#let (slide,) = utils.slides(s)
+#let (slide,) = utils.slides(store)
 #show: slides
 
 = Let's start a new section

--- a/examples/university.typ
+++ b/examples/university.typ
@@ -1,18 +1,18 @@
 #import "../lib.typ": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
-#let s = (s.methods.info)(
-  self: s,
+#let store = themes.university.register(store, aspect-ratio: "16-9")
+#let store = (store.methods.info)(
+  self: store,
   title: [Title],
   subtitle: [Subtitle],
   author: [Authors],
   date: datetime.today(),
   institution: [Institution],
 )
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert) = utils.methods(store)
 #show: init
 
-#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(s)
+#let (slide, title-slide, focus-slide, matrix-slide) = utils.slides(store)
 #show: slides.with(title-slide: false)
 
 #title-slide(authors: ([Author A], [Author B]))

--- a/lib.typ
+++ b/lib.typ
@@ -1,4 +1,4 @@
-#import "slide.typ": s, pause, meanwhile, slides-end, touying-equation, touying-reducer
+#import "slide.typ": store, pause, meanwhile, slides-end, touying-equation, touying-reducer
 #import "utils/utils.typ"
 #import "utils/states.typ"
 #import "utils/pdfpc.typ"

--- a/slide.typ
+++ b/slide.typ
@@ -500,8 +500,8 @@
   }
 }
 
-// build the touying singleton
-#let s = (
+// build the global touying store
+#let store = (
   // info interface
   info: (
     title: none,


### PR DESCRIPTION
Based on the discussion on [discord](https://discord.com/channels/1054443721975922748/1215269725010006096), for better readability and to avoid potential conflicts, we would like to rename `s` to `store`, which is a high-impact refactoring.

Example:

```typst
#import "@preview/touying:0.3.2": *

#let store = themes.simple.register(store)
#let (init, slides) = utils.methods(store)
#show: init

#let (slide,) = utils.slides(store)
#show: slides

= Title

== First Slide

Hello, Touying!

#pause

Hello, Typst!
```