### PR TITLE
refactor: don't export variable `s` by default anymore

### DIFF
--- a/examples/aqua-zh.typ
+++ b/examples/aqua-zh.typ
@@ -1,6 +1,6 @@
 #import "../lib.typ": *
 
-#let s = themes.aqua.register(s, aspect-ratio: "16-9", lang: "zh")
+#let s = themes.aqua.register(aspect-ratio: "16-9", lang: "zh")
 
 #let s = (s.methods.info)(
   self: s, 

--- a/examples/aqua.typ
+++ b/examples/aqua.typ
@@ -1,6 +1,6 @@
 #import "../lib.typ": *
 
-#let s = themes.aqua.register(s, aspect-ratio: "16-9")
+#let s = themes.aqua.register(aspect-ratio: "16-9")
 
 #let s = (s.methods.info)(
   self: s, 

--- a/examples/dewdrop.typ
+++ b/examples/dewdrop.typ
@@ -1,7 +1,6 @@
 #import "../lib.typ": *
 
 #let s = themes.dewdrop.register(
-  s,
   aspect-ratio: "16-9",
   footer: [Dewdrop],
   navigation: "mini-slides",

--- a/examples/example.typ
+++ b/examples/example.typ
@@ -9,7 +9,7 @@
 // Register university theme
 // You can remove the theme registration or replace other themes
 // it can still work normally
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let s = themes.university.register(aspect-ratio: "16-9")
 
 // Global information configuration
 #let s = (s.methods.info)(

--- a/examples/metropolis.typ
+++ b/examples/metropolis.typ
@@ -1,6 +1,6 @@
 #import "../lib.typ": *
 
-#let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: self => self.info.institution)
+#let s = themes.metropolis.register(aspect-ratio: "16-9", footer: self => self.info.institution)
 #let s = (s.methods.info)(
   self: s,
   title: [Title],

--- a/examples/simple.typ
+++ b/examples/simple.typ
@@ -1,6 +1,6 @@
 #import "../lib.typ": *
 
-#let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
+#let s = themes.simple.register(aspect-ratio: "16-9", footer: [Simple slides])
 #let (init, slides) = utils.methods(s)
 #show: init
 

--- a/examples/slides.typ
+++ b/examples/slides.typ
@@ -1,8 +1,9 @@
 #import "../lib.typ": *
 
-// #let s = themes.simple.register(s, aspect-ratio: "16-9", footer: [Simple slides])
-// #let s = themes.metropolis.register(s, aspect-ratio: "16-9", footer: [Custom footer])
-// #let s = themes.dewdrop.register(s, aspect-ratio: "16-9", footer: [Dewdrop])
+#let s = themes.default.register(aspect-ratio: "16-9")
+// #let s = themes.simple.register(aspect-ratio: "16-9", footer: [Simple slides])
+// #let s = themes.metropolis.register(aspect-ratio: "16-9", footer: [Custom footer])
+// #let s = themes.dewdrop.register(aspect-ratio: "16-9", footer: [Dewdrop])
 #let s = (s.methods.info)(
   self: s,
   title: [Title],

--- a/examples/university.typ
+++ b/examples/university.typ
@@ -1,6 +1,6 @@
 #import "../lib.typ": *
 
-#let s = themes.university.register(s, aspect-ratio: "16-9")
+#let s = themes.university.register(aspect-ratio: "16-9")
 #let s = (s.methods.info)(
   self: s,
   title: [Title],

--- a/lib.typ
+++ b/lib.typ
@@ -1,4 +1,4 @@
-#import "slide.typ": s, pause, meanwhile, slides-end, touying-equation, touying-reducer
+#import "slide.typ": pause, meanwhile, slides-end, touying-equation, touying-reducer
 #import "utils/utils.typ"
 #import "utils/states.typ"
 #import "utils/pdfpc.typ"

--- a/themes/aqua.typ
+++ b/themes/aqua.typ
@@ -1,10 +1,11 @@
+#import "../slide.typ": s
 #import "../utils/utils.typ"
 #import "../utils/states.typ"
 #import "../utils/components.typ"
 
 #let title-slide(self: none, ..args) = {
   self = utils.empty-page(self)
-  self.page-args = self.page-args + (
+  self.page-args += (
     margin: (top: 30%, left: 17%, right: 17%, bottom: 0%),
     background: utils.call-or-display(self, self.aqua-background),
   )
@@ -35,7 +36,7 @@
 
 #let outline-slide(self: none, enum-args: (:), leading: 50pt) = {
   self = utils.empty-page(self)
-  self.page-args = self.page-args + (
+  self.page-args += (
     background: utils.call-or-display(self, self.aqua-background),
   )
   set text(size: 30pt, fill: self.colors.primary)
@@ -79,7 +80,7 @@
 
 #let new-section-slide(self: none, section) = {
   self = utils.empty-page(self)
-  self.page-args = self.page-args + (
+  self.page-args += (
     margin: (left:0%, right:0%, top: 20%, bottom:0%),
     background: utils.call-or-display(self, self.aqua-background),
   )
@@ -134,9 +135,9 @@
 }
 
 #let register(
+  self: s,
   aspect-ratio: "16-9",
   lang: "en",
-  self,
 ) = {
   assert(lang in ("zh", "en"), message: "lang must be 'zh' or 'en'")
 

--- a/themes/default.typ
+++ b/themes/default.typ
@@ -1,0 +1,9 @@
+#import "../slide.typ": s
+
+// export default self
+#let register(self: s, aspect-ratio: "16-9") = {
+  self.page-args += (
+    paper: "presentation-" + aspect-ratio,
+  )
+  self
+}

--- a/themes/dewdrop.typ
+++ b/themes/dewdrop.typ
@@ -1,6 +1,7 @@
 // This theme is inspired by https://github.com/zbowang/BeamerTheme
 // The typst version was written by https://github.com/OrangeX4
 
+#import "../slide.typ": s
 #import "../utils/utils.typ"
 #import "../utils/states.typ"
 
@@ -11,7 +12,7 @@
   footer: auto,
   ..args,
 ) = {
-  self.page-args = self.page-args + (
+  self.page-args += (
     fill: self.colors.neutral-lightest,
   )
   if footer != auto {
@@ -82,7 +83,7 @@
 
 #let focus-slide(self: none, body) = {
   self = utils.empty-page(self)
-  self.page-args = self.page-args + (
+  self.page-args += (
     fill: self.colors.primary,
     margin: 2em,
   )
@@ -223,6 +224,7 @@
 }
 
 #let register(
+  self: s,
   aspect-ratio: "16-9",
   navigation: "sidebar",
   sidebar: (width: 10em),
@@ -231,7 +233,6 @@
   footer-right: states.slide-counter.display() + " / " + states.last-slide-number,
   primary: rgb("#0c4842"),
   alpha: 70%,
-  self,
 ) = {
   assert(navigation in ("sidebar", "mini-slides", none), message: "navigation must be one of sidebar, mini-slides, none")
   // color theme
@@ -268,7 +269,7 @@
     h(1fr)
     text(fill: self.colors.neutral-darkest.lighten(20%), utils.call-or-display(self, self.d-footer-right))
   }
-  self.page-args = self.page-args + (
+  self.page-args += (
     paper: "presentation-" + aspect-ratio,
     fill: self.colors.neutral-lightest,
     header: header,

--- a/themes/metropolis.typ
+++ b/themes/metropolis.typ
@@ -7,6 +7,7 @@
 // #set strong(delta: 100)
 // #set par(justify: true)
 
+#import "../slide.typ": s
 #import "../utils/utils.typ"
 #import "../utils/states.typ"
 #import "../utils/components.typ"
@@ -20,7 +21,7 @@
   align: horizon,
   ..args,
 ) = {
-  self.page-args = self.page-args + (
+  self.page-args += (
     fill: self.colors.neutral-lightest,
   )
   if title != auto {
@@ -92,7 +93,7 @@
 
 #let focus-slide(self: none, body) = {
   self = utils.empty-page(self)
-  self.page-args = self.page-args + (
+  self.page-args += (
     fill: self.colors.primary-dark,
     margin: 2em,
   )
@@ -111,12 +112,12 @@
 }
 
 #let register(
+  self: s,
   aspect-ratio: "16-9",
   header: states.current-section-title,
   footer: [],
   footer-right: states.slide-counter.display() + " / " + states.last-slide-number,
   footer-progress: true,
-  self,
 ) = {
   // color theme
   self = (self.methods.colors)(
@@ -160,7 +161,7 @@
       place(bottom, block(height: 2pt, width: 100%, spacing: 0pt, utils.call-or-display(self, self.m-progress-bar)))
     }
   }
-  self.page-args = self.page-args + (
+  self.page-args += (
     paper: "presentation-" + aspect-ratio,
     header: header,
     footer: footer,

--- a/themes/simple.typ
+++ b/themes/simple.typ
@@ -1,6 +1,7 @@
 // This theme is from https://github.com/andreasKroepelin/polylux/blob/main/themes/simple.typ
 // Author: Andreas Kröpelin
 
+#import "../slide.typ": s
 #import "../utils/utils.typ"
 #import "../utils/states.typ"
 
@@ -40,13 +41,13 @@
 }
 
 #let register(
+  self: s,
   aspect-ratio: "16-9",
   footer: [],
   footer-right: states.slide-counter.display() + " / " + states.last-slide-number,
   background: rgb("#ffffff"),
   foreground: rgb("#000000"),
   primary: aqua.darken(50%),
-  self,
 ) = {
   let deco-format(it) = text(size: .6em, fill: gray, it)
   // color theme
@@ -67,7 +68,7 @@
     deco-format(sections.last().title)
   })
   let footer(self) = deco-format(self.simple-footer + h(1fr) + self.simple-footer-right)
-  self.page-args = self.page-args + (
+  self.page-args += (
     paper: "presentation-" + aspect-ratio,
     fill: self.colors.neutral-lightest,
     header: header,

--- a/themes/themes.typ
+++ b/themes/themes.typ
@@ -1,3 +1,4 @@
+#import "default.typ"
 #import "simple.typ"
 #import "metropolis.typ"
 #import "dewdrop.typ"

--- a/themes/university.typ
+++ b/themes/university.typ
@@ -2,6 +2,7 @@
 
 // Originally contributed by Pol Dellaiera - https://github.com/drupol
 
+#import "../slide.typ": s
 #import "../utils/utils.typ"
 #import "../utils/states.typ"
 #import "../utils/components.typ"
@@ -105,7 +106,7 @@
     background-color
   }
   self = utils.empty-page(self)
-  self.page-args = self.page-args + (
+  self.page-args += (
     fill: self.colors.primary-dark,
     margin: 1em,
     ..(if background-color != none { (fill: background-color) }),
@@ -169,9 +170,9 @@
 }
 
 #let register(
+  self: s,
   aspect-ratio: "16-9",
   progress-bar: true,
-  self,
 ) = {
   // color theme
   self = (self.methods.colors)(
@@ -228,7 +229,7 @@
     utils.call-or-display(self, self.uni-footer)
   }
 
-  self.page-args = self.page-args + (
+  self.page-args += (
     paper: "presentation-" + aspect-ratio,
     header: header,
     footer: footer,


### PR DESCRIPTION
Don't export variable `s` by default anymore.

1. make `self` parameter in `register` a named parameter instead of positional parameter, and change syntax `#let s = themes.university.register(s, aspect-ratio: "16-9")` to `#let s = themes.university.register(aspect-ratio: "16-9")`.
2. add `default` theme to export a empty/default `s`, like `#let s = themes.default.register(aspect-ratio: "16-9")`

Alternative to #14