### PR TITLE
docs: initialize variable s in table of contents example

### DIFF
--- a/docs/docs/sections.md
+++ b/docs/docs/sections.md
@@ -61,6 +61,7 @@ Displaying a table of contents in Touying is straightforward:
 ```typst
 #import "@preview/touying:0.3.2": *
 
+#let s = themes.simple.register()
 #let (init, slides, alert, touying-outline) = utils.methods(s)
 #show: init
 


### PR DESCRIPTION
Hello,

The third example (table of contents) in the sections and subsections chapter: https://touying-typ.github.io/touying/docs/sections does not compile for me due to `error: unknown variable: s`. I think a line similar to the one I've added was missing.

The compiled PDF still doesn't exactly match the corresponding .png example. The compiled PDF in this pull request adds a gray header titled "Section" - I'm not sure if that is because simple is the wrong theme or if the .png just needs to be updated.