### PR TITLE
feat: access subslide and repeat in footer and header

### DIFF
--- a/slide.typ
+++ b/slide.typ
@@ -186,7 +186,6 @@
     // if it is a function, then call it with self
     if type(it) == function {
       // subslide index
-      self.subslide = index
       it = it(self)
     }
     // parse the content
@@ -385,10 +384,12 @@
     }
   }
   // page header and footer
-  let header = utils.call-or-display(self, self.page-args.at("header", default: none))
-  let footer = utils.call-or-display(self, self.page-args.at("footer", default: none))
   // for speed up, do not parse the content if repeat is none
   if repeat == none {
+    self.repeat = repeat
+    self.subslide = 1
+    let header = utils.call-or-display(self, self.page-args.at("header", default: none))
+    let footer = utils.call-or-display(self, self.page-args.at("footer", default: none))
     return {
       header = _update-states(1) + header
       page(..(self.page-args + (header: header, footer: footer)), setting-with-pad(
@@ -407,6 +408,10 @@
     repeat = repetitions
   }
   if self.handout {
+    self.repeat = repeat
+    self.subslide = repeat
+    let header = utils.call-or-display(self, self.page-args.at("header", default: none))
+    let footer = utils.call-or-display(self, self.page-args.at("footer", default: none))
     let (conts, _) = _parse-content(self: self, index: repeat, ..bodies)
     header = _update-states(1) + header
     page(..(self.page-args + (header: header, footer: footer)), setting-with-pad(
@@ -416,7 +421,11 @@
     // render all the subslides
     let result = ()
     let current = 1
+    self.repeat = repeat
     for i in range(1, repeat + 1) {
+      self.subslide = i
+      let header = utils.call-or-display(self, self.page-args.at("header", default: none))
+      let footer = utils.call-or-display(self, self.page-args.at("footer", default: none))
       let new-header = header
       let (conts, _) = _parse-content(self: self, index: i, ..bodies)
       // update the counter in the first subslide

--- a/slide.typ
+++ b/slide.typ
@@ -323,6 +323,12 @@
   return (result-arr, max-repetitions)
 }
 
+#let _get-header-footer(self) = {
+  let header = utils.call-or-display(self, self.page-args.at("header", default: none))
+  let footer = utils.call-or-display(self, self.page-args.at("footer", default: none))
+  (header, footer)
+}
+
 // touying-slide
 #let touying-slide(
   self: none,
@@ -383,20 +389,6 @@
       states._sections-step(repetitions)
     }
   }
-  // page header and footer
-  // for speed up, do not parse the content if repeat is none
-  if repeat == none {
-    self.repeat = repeat
-    self.subslide = 1
-    let header = utils.call-or-display(self, self.page-args.at("header", default: none))
-    let footer = utils.call-or-display(self, self.page-args.at("footer", default: none))
-    return {
-      header = _update-states(1) + header
-      page(..(self.page-args + (header: header, footer: footer)), setting-with-pad(
-        page-preamble(1) + composer-with-side-by-side(..bodies)
-      ))
-    }
-  }
   // for single page slide, get the repetitions
   if repeat == auto {
     let (_, repetitions) = _parse-content(
@@ -407,11 +399,22 @@
     )
     repeat = repetitions
   }
+  self.repeat = repeat
+  self.subslide = 1
+  let (header, footer) = _get-header-footer(self)
+  // page header and footer
+  // for speed up, do not parse the content if repeat is none
+  if repeat == none {
+    return {
+      header = _update-states(1) + header
+      page(..(self.page-args + (header: header, footer: footer)), setting-with-pad(
+        page-preamble(1) + composer-with-side-by-side(..bodies)
+      ))
+    }
+  }
+  
   if self.handout {
-    self.repeat = repeat
     self.subslide = repeat
-    let header = utils.call-or-display(self, self.page-args.at("header", default: none))
-    let footer = utils.call-or-display(self, self.page-args.at("footer", default: none))
     let (conts, _) = _parse-content(self: self, index: repeat, ..bodies)
     header = _update-states(1) + header
     page(..(self.page-args + (header: header, footer: footer)), setting-with-pad(
@@ -421,11 +424,9 @@
     // render all the subslides
     let result = ()
     let current = 1
-    self.repeat = repeat
     for i in range(1, repeat + 1) {
       self.subslide = i
-      let header = utils.call-or-display(self, self.page-args.at("header", default: none))
-      let footer = utils.call-or-display(self, self.page-args.at("footer", default: none))
+      let (header, footer) = _get-header-footer(self)
       let new-header = header
       let (conts, _) = _parse-content(self: self, index: i, ..bodies)
       // update the counter in the first subslide

--- a/utils/utils.typ
+++ b/utils/utils.typ
@@ -1,10 +1,9 @@
 // OOP: call it or display it
 #let call-or-display(self, it) = {
   if type(it) == function {
-    return it(self)
-  } else {
-    return it
+    it = it(self)
   }
+  return [#it]
 }
 
 // OOP: empty page


### PR DESCRIPTION
Implement #21.

we can access `subslide` and `repeat` in footer by code like `footer: self => self.subslide` and `footer: self => self.repeat`.