### PR TITLE
refactor: remove `padding` and add `full-header`, `full-footer` to support footnote

### DIFF
--- a/themes/aqua.typ
+++ b/themes/aqua.typ
@@ -194,11 +194,15 @@
       circle(radius: 13pt, fill: white))
   }
   let header(self) = {
-    place(center + top, dy: 45%,
-      rect(width: 100%, height: 100%, fill: self.colors.primary))
-    place(left + top, line(start: (30%, 30%), end: (27%, 200%), stroke: 7pt + white))
-    place(left + bottom, dx: 4%, dy: 15%,
-      text(fill:white, self.aqua-title))
+    place(center + top, dy: .5em,
+      rect(
+        width: 100%,
+        height: 1.8em,
+        fill: self.colors.primary,
+        align(left + horizon, h(1.5em) + text(fill:white, self.aqua-title))
+      )
+    )
+    place(left + top, line(start: (30%, 0%), end: (27%, 100%), stroke: .5em + white))
   }
   let footer(self) = {
     set text(size: 0.8em)
@@ -206,11 +210,10 @@
   }
   self.page-args += (
     paper: "presentation-" + aspect-ratio,
-    margin: (x: 0em, top: 10%, bottom: 10%),
+    margin: (x: 2em, top: 3.5em, bottom: 2em),
     header: header,
     footer: footer,
   )
-  self.padding += (x: 5%, top: 7%)
   self.methods.init = (self: none, body) => {
     set text(size: 20pt)
     body

--- a/themes/dewdrop.typ
+++ b/themes/dewdrop.typ
@@ -278,13 +278,12 @@
     header-ascent: 0em,
     footer-descent: 0em,
   ) + if navigation == "sidebar" {(
-    margin: (top: 2em, bottom: 1em, x: 0em),
+    margin: (top: 2em, bottom: 1em, x: sidebar.width),
   )} else if navigation == "mini-slides" {(
-    margin: (top: mini-slides.height, bottom: 2em, x: 0em),
+    margin: (top: mini-slides.height, bottom: 2em, x: mini-slides.x),
   )} else {(
-    margin: (top: 2em, bottom: 2em, x: 0em),
+    margin: (top: 2em, bottom: 2em, x: mini-slides.x),
   )}
-  self.padding = (x: if navigation == "sidebar" { sidebar.width } else { mini-slides.x }, y: 0em)
   // register methods
   self.methods.slide = slide
   self.methods.title-slide = title-slide

--- a/themes/metropolis.typ
+++ b/themes/metropolis.typ
@@ -167,9 +167,8 @@
     footer: footer,
     header-ascent: 30%,
     footer-descent: 30%,
-    margin: (top: 3em, bottom: 1.5em, x: 0em),
+    margin: (top: 3em, bottom: 1.5em, x: 2em),
   )
-  self.padding = (x: 2em, y: 0em)
   // register methods
   self.methods.slide = slide
   self.methods.title-slide = title-slide

--- a/themes/simple.typ
+++ b/themes/simple.typ
@@ -18,7 +18,7 @@
 }
 
 #let centered-slide(self: none, section: none, ..args) = {
-  self = utils.empty-page(self)
+  self = utils.empty-page(self, margin: none)
   (self.methods.touying-slide)(self: self, repeat: none, section: section, ..args.named(),
     align(center + horizon, if section != none { heading(level: 1, utils.unify-section(section).title) } + args.pos().sum(default: []))
   )
@@ -33,7 +33,7 @@
 }
 
 #let focus-slide(self: none, background: auto, foreground: white, body) = {
-  self = utils.empty-page(self)
+  self = utils.empty-page(self, margin: none)
   self.page-args.fill = if background == auto { self.colors.primary } else { background }
   set text(fill: foreground, size: 1.5em)
   centered-slide(self: self, align(center + horizon, body))
@@ -75,6 +75,8 @@
     footer-descent: 1em,
     header-ascent: 1em,
   )
+  self.full-header = false
+  self.full-footer = false
   // register methods
   self.methods.slide = slide
   self.methods.title-slide = title-slide

--- a/themes/university.typ
+++ b/themes/university.typ
@@ -262,9 +262,8 @@
     footer: footer,
     header-ascent: 0em,
     footer-descent: 0em,
-    margin: (top: 2.5em, bottom: 1em, x: 0em),
+    margin: (top: 2.5em, bottom: 1em, x: 2em),
   )
-  self.padding = (x: 2em, y: 0em)
   // register methods
   self.methods.slide = slide
   self.methods.title-slide = title-slide

--- a/utils/utils.typ
+++ b/utils/utils.typ
@@ -7,13 +7,14 @@
 }
 
 // OOP: empty page
-#let empty-page(self) = {
+#let empty-page(self, margin: (x: 0em, y: 0em)) = {
   self.page-args += (
     header: none,
     footer: none,
-    margin: (x: 0em, y: 0em),
   )
-  self.padding = (x: 0em, y: 0em)
+  if margin != none {
+    self.page-args += (margin: margin)
+  }
   self
 }
 


### PR DESCRIPTION
![](https://github.com/touying-typ/touying/assets/34951714/6127d231-86f3-4262-b7c6-b199d47ae12b)

(Original page layout ↑)

To support footnote, we need to modify the page layout of the slide from:

```typst
page(
  header: header,
  pad(
    body
  ),
  footer: footer,
)
```

to

```
set page(
  header: negative-pad(header),
  footer: negative-pad(footer),
)
body
```

structure.

Where `let negative-pad = pad.with(x: -margin.x)`, which extends the header/footer to occupy the entire width of the page.

As a result, we remove the `self.padding` parameter and add `self.full-header` and `self.full-footer` to control whether this feature is enabled (not enabled for the simple theme, but enabled for all other themes).

This PR is a breaking change, but it enables support for footnote #26 and allows normal usage of `set align(horizon)` set rule.

cc @sefidel and @fran-miao