### PR TITLE
feat: add speaker note support for dual screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,14 @@ In fact, Touying provides various styles for writing slides. For example, the ab
 #let fletcher-diagram = touying-reducer.with(reduce: fletcher.diagram, cover: fletcher.hide)
 
 // Register university theme
-// You can remove the theme registration or replace other themes
-// it can still work normally
+// You can replace it with other themes and it can still work normally
 #let s = themes.university.register(aspect-ratio: "16-9")
 
 // Set the numbering of section and subsection
 #let s = (s.methods.numbering)(self: s, section: "1.", "1.1")
+
+// Set the speaker notes configuration
+// #let s = (s.methods.show-notes-on-second-screen)(self: s, right)
 
 // Global information configuration
 #let s = (s.methods.info)(
@@ -173,7 +175,7 @@ In fact, Touying provides various styles for writing slides. For example, the ab
 #let proof = thmproof("proof", "Proof")
 
 // Extract methods
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert, speaker-note) = utils.methods(s)
 #show: init
 
 #show strong: alert
@@ -196,6 +198,10 @@ Just like this.
 
 Meanwhile, #pause we can also use `#meanwhile` to #pause display other content synchronously.
 
+#speaker-note[
+  + This is a speaker note.
+  + You won't see it unless you use `#let s = (s.math.show-notes-on-second-screen)(self: s, right)`
+]
 
 == Complex Animation
 
@@ -339,6 +345,7 @@ Fletcher Animation in Touying:
 #slide[
   Please pay attention to the current slide number.
 ]
+
 ```
 
 ![image](https://github.com/touying-typ/touying/assets/34951714/5ac2b11c-9e77-4389-ade6-682c9fc3e1fb)

--- a/docs/docs/external/pympress.md
+++ b/docs/docs/external/pympress.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 2
+---
+
+# Pympress
+
+[Pympress](https://github.com/Cimbali/pympress) 是一种 PDF 演示工具，专为演示文稿和公开演讲等双屏设置而设计。高度可配置、功能齐全且可移植。
+
+
+## 笔记支持
+
+```typst
+#import "@preview/touying:0.4.0": *
+
+#let s = themes.university.register(aspect-ratio: "16-9")
+
+// Set the speaker notes configuration, you can show it by pympress
+#let s = (s.methods.show-notes-on-second-screen)(self: s, right)
+
+#let (init, slides, touying-outline, alert, speaker-note) = utils.methods(s)
+#show: init
+
+#let (slide, empty-slide) = utils.slides(s)
+#show: slides
+
+= Animation
+
+== Simple Animation
+
+We can use `#pause` to #pause display something later.
+
+#pause
+
+Just like this.
+
+#meanwhile
+
+Meanwhile, #pause we can also use `#meanwhile` to #pause display other content synchronously.
+
+#speaker-note[
+  + This is a speaker note.
+  + You won't see it unless you use `#let s = (s.math.show-notes-on-second-screen)(self: s, right)`
+]
+```
+
+![image](https://github.com/touying-typ/touying/assets/34951714/b43c7f99-c5f9-4084-aa70-c1561e8aafee)
+
+然后我们就可以使用 pympress 放映了。
+
+![image](https://github.com/touying-typ/touying/assets/34951714/afbe17cb-46d4-4507-90e8-959c53de95d5)
+

--- a/docs/docs/external/typst-preview.md
+++ b/docs/docs/external/typst-preview.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Typst Preview

--- a/docs/docs/start.md
+++ b/docs/docs/start.md
@@ -62,8 +62,7 @@ you can use the university theme. For more detailed tutorials on themes, you can
 #let fletcher-diagram = touying-reducer.with(reduce: fletcher.diagram, cover: fletcher.hide)
 
 // Register university theme
-// You can remove the theme registration or replace other themes
-// it can still work normally
+// You can replace it with other themes and it can still work normally
 #let s = themes.university.register(aspect-ratio: "16-9")
 
 // Set the numbering of section and subsection

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/external/pympress.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/external/pympress.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 2
+---
+
+# Pympress
+
+[Pympress](https://github.com/Cimbali/pympress) is a PDF presentation tool designed for dual-screen setups such as presentations and public talks. Highly configurable, fully-featured, and portable
+
+
+## Speaker Notes
+
+```typst
+#import "@preview/touying:0.4.0": *
+
+#let s = themes.university.register(aspect-ratio: "16-9")
+
+// Set the speaker notes configuration, you can show it by pympress
+#let s = (s.methods.show-notes-on-second-screen)(self: s, right)
+
+#let (init, slides, touying-outline, alert, speaker-note) = utils.methods(s)
+#show: init
+
+#let (slide, empty-slide) = utils.slides(s)
+#show: slides
+
+= Animation
+
+== Simple Animation
+
+We can use `#pause` to #pause display something later.
+
+#pause
+
+Just like this.
+
+#meanwhile
+
+Meanwhile, #pause we can also use `#meanwhile` to #pause display other content synchronously.
+
+#speaker-note[
+  + This is a speaker note.
+  + You won't see it unless you use `#let s = (s.math.show-notes-on-second-screen)(self: s, right)`
+]
+```
+
+![image](https://github.com/touying-typ/touying/assets/34951714/b43c7f99-c5f9-4084-aa70-c1561e8aafee)
+
+Then we can use the pympress to show it.
+
+![image](https://github.com/touying-typ/touying/assets/34951714/afbe17cb-46d4-4507-90e8-959c53de95d5)
+

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/external/typst-preview.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/external/typst-preview.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Typst Preview

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/start.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/start.md
@@ -52,8 +52,7 @@ Hello, Typst!
 #let fletcher-diagram = touying-reducer.with(reduce: fletcher.diagram, cover: fletcher.hide)
 
 // Register university theme
-// You can remove the theme registration or replace other themes
-// it can still work normally
+// You can replace it with other themes and it can still work normally
 #let s = themes.university.register(aspect-ratio: "16-9")
 
 // Set the numbering of section and subsection

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.2+/start.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.2+/start.md
@@ -51,8 +51,7 @@ Hello, Typst!
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
 // Register university theme
-// You can remove the theme registration or replace other themes
-// it can still work normally
+// You can replace it with other themes and it can still work normally
 #let s = themes.university.register(aspect-ratio: "16-9")
 
 // Global information configuration

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/start.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.3.x/start.md
@@ -51,8 +51,7 @@ Hello, Typst!
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
 // Register university theme
-// You can remove the theme registration or replace other themes
-// it can still work normally
+// You can replace it with other themes and it can still work normally
 #let s = themes.university.register(s, aspect-ratio: "16-9")
 
 // Global information configuration

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.4.0+/start.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/version-0.4.0+/start.md
@@ -52,8 +52,7 @@ Hello, Typst!
 #let fletcher-diagram = touying-reducer.with(reduce: fletcher.diagram, cover: fletcher.hide)
 
 // Register university theme
-// You can remove the theme registration or replace other themes
-// it can still work normally
+// You can replace it with other themes and it can still work normally
 #let s = themes.university.register(aspect-ratio: "16-9")
 
 // Set the numbering of section and subsection

--- a/docs/versioned_docs/version-0.3.2+/start.md
+++ b/docs/versioned_docs/version-0.3.2+/start.md
@@ -61,8 +61,7 @@ you can use the university theme. For more detailed tutorials on themes, you can
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
 // Register university theme
-// You can remove the theme registration or replace other themes
-// it can still work normally
+// You can replace it with other themes and it can still work normally
 #let s = themes.university.register(aspect-ratio: "16-9")
 
 // Global information configuration

--- a/docs/versioned_docs/version-0.3.x/start.md
+++ b/docs/versioned_docs/version-0.3.x/start.md
@@ -61,8 +61,7 @@ you can use the university theme. For more detailed tutorials on themes, you can
 #let fletcher-diagram = touying-reducer.with(reduce: (arr, ..args) => fletcher.diagram(..args, ..arr))
 
 // Register university theme
-// You can remove the theme registration or replace other themes
-// it can still work normally
+// You can replace it with other themes and it can still work normally
 #let s = themes.university.register(s, aspect-ratio: "16-9")
 
 // Global information configuration

--- a/docs/versioned_docs/version-0.4.0+/start.md
+++ b/docs/versioned_docs/version-0.4.0+/start.md
@@ -62,8 +62,7 @@ you can use the university theme. For more detailed tutorials on themes, you can
 #let fletcher-diagram = touying-reducer.with(reduce: fletcher.diagram, cover: fletcher.hide)
 
 // Register university theme
-// You can remove the theme registration or replace other themes
-// it can still work normally
+// You can replace it with other themes and it can still work normally
 #let s = themes.university.register(aspect-ratio: "16-9")
 
 // Set the numbering of section and subsection

--- a/examples/example.typ
+++ b/examples/example.typ
@@ -14,7 +14,7 @@
 // Set the numbering of section and subsection
 #let s = (s.methods.numbering)(self: s, section: "1.", "1.1")
 
-// Set the speaker notes configuration
+// Set the speaker notes configuration, you can show it by pympress
 // #let s = (s.methods.show-notes-on-second-screen)(self: s, right)
 
 // Global information configuration

--- a/examples/example.typ
+++ b/examples/example.typ
@@ -8,12 +8,14 @@
 #let fletcher-diagram = touying-reducer.with(reduce: fletcher.diagram, cover: fletcher.hide)
 
 // Register university theme
-// You can remove the theme registration or replace other themes
-// it can still work normally
+// You can replace it with other themes and it can still work normally
 #let s = themes.university.register(aspect-ratio: "16-9")
 
 // Set the numbering of section and subsection
 #let s = (s.methods.numbering)(self: s, section: "1.", "1.1")
+
+// Set the speaker notes configuration
+// #let s = (s.methods.show-notes-on-second-screen)(self: s, right)
 
 // Global information configuration
 #let s = (s.methods.info)(
@@ -57,7 +59,7 @@
 #let proof = thmproof("proof", "Proof")
 
 // Extract methods
-#let (init, slides, touying-outline, alert) = utils.methods(s)
+#let (init, slides, touying-outline, alert, speaker-note) = utils.methods(s)
 #show: init
 
 #show strong: alert
@@ -80,6 +82,10 @@ Just like this.
 
 Meanwhile, #pause we can also use `#meanwhile` to #pause display other content synchronously.
 
+#speaker-note[
+  + This is a speaker note.
+  + You won't see it unless you use `#let s = (s.math.show-notes-on-second-screen)(self: s, right)`
+]
 
 == Complex Animation
 

--- a/slide.typ
+++ b/slide.typ
@@ -443,9 +443,69 @@
   it => pad(..pad-args, cell(it))
 }
 
+#let _get-page-extra-args(self) = {
+  if self.show-notes-on-second-screen == right {
+    let margin = self.page-args.margin
+    assert(
+      self.page-args.paper == "presentation-16-9" or self.page-args.paper == "presentation-4-3",
+      message: "The paper of page should be presentation-16-9 or presentation-4-3"
+    )
+    let page-width = if self.page-args.paper == "presentation-16-9" { 841.89pt } else { 793.7pt }
+    if type(margin) != dictionary and type(margin) != length and type(margin) != relative {
+      return (:)
+    }
+    if type(margin) == length or type(margin) == relative {
+      margin = (x: margin, y: margin)
+    }
+    if "right" not in margin {
+      assert("x" in margin, message: "The margin should have right or x")
+      margin.right = margin.x
+    }
+    margin.right += page-width
+    return (margin: margin, width: 2 * page-width)
+  } else {
+    return (:)
+  }
+}
+
 #let _get-header-footer(self) = {
   let header = utils.call-or-display(self, self.page-args.at("header", default: none))
   let footer = utils.call-or-display(self, self.page-args.at("footer", default: none))
+  // speaker note
+  if self.show-notes-on-second-screen == right {
+    assert(
+      self.page-args.paper == "presentation-16-9" or self.page-args.paper == "presentation-4-3",
+      message: "The paper of page should be presentation-16-9 or presentation-4-3"
+    )
+    let page-width = if self.page-args.paper == "presentation-16-9" { 841.89pt } else { 793.7pt }
+    let page-height = if self.page-args.paper == "presentation-16-9" { 473.56pt } else { 595.28pt }
+    footer += place(
+      left + bottom,
+      dx: page-width,
+      block(
+        fill: rgb("#E6E6E6"),
+        width: page-width,
+        height: page-height,
+        {
+          set align(left + top)
+          block(
+            width: 100%, height: 88pt, inset: (left: 32pt, top: 16pt), outset: 0pt, fill: rgb("#CCCCCC"), 
+            {
+              set text(24pt)
+              states.current-section-title
+              linebreak()
+              [ --- ]
+              states.current-slide-title
+            },
+          )
+          pad(x: 48pt, states.current-slide-note)
+          // clear the slide note
+          states.slide-note-state.update(none)
+        }
+      )
+    )
+  }
+  // negative padding
   if self.full-header or self.full-footer {
     let negative-pad = _get-negative-pad(self)
     if self.full-header {
@@ -525,6 +585,8 @@
       }
       states._sections-step(repetitions)
     }
+    // 3. slide title part
+    states.slide-title-state.update(title)
   }
   self.subslide = 1
   // for single page slide, get the repetitions
@@ -539,6 +601,7 @@
   }
   self.repeat = repeat
   let (header, footer) = _get-header-footer(self)
+  let page-extra-args = _get-page-extra-args(self)
   // page header and footer
   // for speed up, do not parse the content if repeat is none
   if repeat == none {
@@ -551,7 +614,7 @@
         }
       })
       header = _update-states(1) + header
-      set page(..(self.page-args + (header: header, footer: footer)))
+      set page(..(self.page-args + page-extra-args + (header: header, footer: footer)))
       setting(
         page-preamble(1) + composer-with-side-by-side(..conts)
       )
@@ -562,7 +625,7 @@
     self.subslide = repeat
     let (conts, _) = _parse-content(self: self, index: repeat, ..bodies)
     header = _update-states(1) + header
-    set page(..(self.page-args + (header: header, footer: footer)))
+    set page(..(self.page-args + page-extra-args + (header: header, footer: footer)))
     setting(
       page-preamble(1) + composer-with-side-by-side(..conts)
     )
@@ -580,7 +643,7 @@
         new-header = _update-states(repeat) + new-header
       }
       result.push({
-        set page(..(self.page-args + (header: new-header, footer: footer)))
+        set page(..(self.page-args + page-extra-args + (header: new-header, footer: footer)))
         setting(page-preamble(i) + composer-with-side-by-side(..conts))
       })
     }
@@ -751,11 +814,13 @@
     header: none,
     footer: none,
     fill: rgb("#ffffff"),
-    margin: (x: 7%, y: 12%),
+    margin: (x: 3em, y: 2.8em),
   ),
   // full header / footer
   full-header: true,
   full-footer: true,
+  // speaker notes
+  show-notes-on-second-screen: none,
   // numbering
   numbering: none,
   // duplicate for section and subsection
@@ -864,6 +929,19 @@
     appendix-in-outline: (self: none, value) => {
       self.appendix-in-outline = value
       self
+    },
+    show-notes-on-second-screen: (self: none, value) => {
+      assert(value == none or value == right, message: "value should be none or right")
+      self.show-notes-on-second-screen = value
+      self
+    },
+    speaker-note: (self: none, pdfpc: false, setting: it => it, note) => {
+      if pdfpc {
+        pdfpc.speaker-note(note)
+      }
+      if self.show-notes-on-second-screen != none {
+        states.slide-note-state.update(setting(note))
+      }
     }
   ),
 )

--- a/slide.typ
+++ b/slide.typ
@@ -488,10 +488,10 @@
         height: page-height,
         {
           set align(left + top)
+          set text(size: 24pt, fill: black, weight: "regular")
           block(
             width: 100%, height: 88pt, inset: (left: 32pt, top: 16pt), outset: 0pt, fill: rgb("#CCCCCC"), 
             {
-              set text(24pt)
               states.current-section-title
               linebreak()
               [ --- ]

--- a/themes/aqua.typ
+++ b/themes/aqua.typ
@@ -123,6 +123,7 @@
   }
   (self.methods.touying-slide)(
     self: self,
+    title: title,
     setting: body => {
       show heading.where(level:1): body => text(fill: self.colors.primary-light)[#body#v(3%)]
       body

--- a/themes/aqua.typ
+++ b/themes/aqua.typ
@@ -5,10 +5,8 @@
 
 #let title-slide(self: none, ..args) = {
   self = utils.empty-page(self)
-  self.page-args += (
-    margin: (top: 30%, left: 17%, right: 17%, bottom: 0%),
-    background: utils.call-or-display(self, self.aqua-background),
-  )
+  self.page-args.margin += (top: 30%, bottom: 0%)
+  self.page-args.background = utils.call-or-display(self, self.aqua-background)
   let info = self.info + args.named()
 
   let content = {
@@ -162,33 +160,37 @@
   self.aqua-footer = footer
   self.aqua-lang = lang
   self.aqua-background = (self) => {
+    let page-width = if self.page-args.paper == "presentation-16-9" { 841.89pt } else { 793.7pt }
+    let r = if self.show-notes-on-second-screen == none { 1.0 } else { 0.5 }
+    let bias1 = - page-width * (1-r)
+    let bias2 = - page-width * 2 * (1-r)
     place(left + top, dx: -15pt, dy: -26pt,
       circle(radius: 40pt, fill: self.colors.primary))
     place(left + top, dx: 65pt, dy: 12pt,
       circle(radius: 21pt, fill: self.colors.primary))
-    place(left + top, dx: 3%, dy: 15%,
+    place(left + top, dx: r * 3%, dy: 15%,
       circle(radius: 13pt, fill: self.colors.primary))
-    place(left + top, dx: 2.5%, dy: 27%,
+    place(left + top, dx: r * 2.5%, dy: 27%,
       circle(radius: 8pt, fill: self.colors.primary))
-    place(right + bottom, dx: 15pt, dy: 26pt,
+    place(right + bottom, dx: 15pt + bias2, dy: 26pt,
       circle(radius: 40pt, fill: self.colors.primary))
-    place(right + bottom, dx: -65pt, dy: -12pt,
+    place(right + bottom, dx: -65pt + bias2, dy: -12pt,
       circle(radius: 21pt, fill: self.colors.primary))
-    place(right + bottom, dx: -3%, dy: -15%,
+    place(right + bottom, dx: r * -3% + bias2, dy: -15%,
       circle(radius: 13pt, fill: self.colors.primary))
-    place(right + bottom, dx: -2.5%, dy: -27%,
+    place(right + bottom, dx: r * -2.5% + bias2, dy: -27%,
       circle(radius: 8pt, fill: self.colors.primary))
-    polygon(fill: self.colors.primary-lightest,
-      (35%, -17%), (70%, 10%), (35%, 30%), (0%, 10%))
-    place(center + horizon, dy: 7%,
-      ellipse(fill: white, width: 45%, height: 120pt))
-    place(center + horizon, dy: 5%,
-      ellipse(fill: self.colors.primary-lightest, width: 40%, height: 80pt))
-    place(center + horizon, dy: 12%,
-      rect(fill: self.colors.primary-lightest, width: 40%, height: 60pt))
-    place(center + horizon, dy: 20%,
-      ellipse(fill: white, width: 40%, height: 70pt))
-    place(center + horizon, dx: 28%, dy: -6%,
+    place(center + horizon, dx: bias1, polygon(fill: self.colors.primary-lightest,
+      (35% * page-width, -17%), (70% * page-width, 10%), (35% * page-width, 30%), (0% * page-width, 10%)))
+    place(center + horizon, dy: 7%, dx: bias1,
+      ellipse(fill: white, width: r * 45%, height: 120pt))
+    place(center + horizon, dy: 5%, dx: bias1,
+      ellipse(fill: self.colors.primary-lightest, width: r * 40%, height: 80pt))
+    place(center + horizon, dy: 12%, dx: bias1,
+      rect(fill: self.colors.primary-lightest, width: r * 40%, height: 60pt))
+    place(center + horizon, dy: 20%, dx: bias1,
+      ellipse(fill: white, width: r * 40%, height: 70pt))
+    place(center + horizon, dx: r * 28% + bias1, dy: -6%,
       circle(radius: 13pt, fill: white))
   }
   let header(self) = {

--- a/themes/metropolis.typ
+++ b/themes/metropolis.typ
@@ -33,6 +33,7 @@
   (self.methods.touying-slide)(
     ..args.named(),
     self: self,
+    title: title,
     setting: body => {
       show: _saved-align.with(align)
       set text(fill: self.colors.primary-dark)

--- a/themes/university.typ
+++ b/themes/university.typ
@@ -34,6 +34,7 @@
   (self.methods.touying-slide)(
     ..args.named(),
     self: self,
+    title: title,
     setting: body => {
       show: args.named().at("setting", default: body => body)
       body

--- a/utils/pdfpc.typ
+++ b/utils/pdfpc.typ
@@ -51,9 +51,9 @@
 }
 
 #let speaker-note(text) = {
-  let text = if type(text) == "string" {
+  let text = if type(text) == str {
     text
-  } else if type(text) == "content" and text.func() == raw {
+  } else if type(text) == content and text.func() == raw {
     text.text.trim()
   } else {
     panic("A note must either be a string or a raw block")

--- a/utils/states.typ
+++ b/utils/states.typ
@@ -15,6 +15,12 @@
 // sections
 #let sections-state = state("touying-sections-state", ((kind: "section", title: none, short-title: none, loc: none, count: 0, children: ()),))
 
+// slide title state
+#let slide-title-state = state("touying-slide-title-state", none)
+
+// slide note state
+#let slide-note-state = state("touying-slide-note-state", none)
+
 #let _new-section(short-title: auto, duplicate: false, title) = locate(loc => {
   sections-state.update(sections => {
     if duplicate or sections.last().title != title or sections.last().short-title != short-title {
@@ -98,6 +104,10 @@
     none
   }
 })
+
+#let current-slide-title = context slide-title-state.get()
+
+#let current-slide-note = context slide-note-state.get()
 
 #let _typst-numbering = numbering
 #let current-section-number(numbering: "01", ignore-zero: true) = locate(loc => {


### PR DESCRIPTION
```typst
#let s = (s.methods.show-notes-on-second-screen)(self: s, right)

#speaker-note[
  + This is a speaker note.
  + You won't see it unless you use `#let s = (s.math.show-notes-on-second-screen)(self: s, right)`
]
```

Add speaker note support for dual screens. It is compatible with beamer, so we can use [dspdfviewer](https://dspdfviewer.danny-edel.de/) or [pympress](https://github.com/Cimbali/pympress) for presentation with speaker notes. I personally recommend pympress because of its feature-rich and simple installation.

![image](https://github.com/touying-typ/touying/assets/34951714/b43c7f99-c5f9-4084-aa70-c1561e8aafee)

![image](https://github.com/touying-typ/touying/assets/34951714/afbe17cb-46d4-4507-90e8-959c53de95d5)

https://github.com/touying-typ/touying/blob/dc0910b5af6fb12f8cd4d746bb672373d60b65a9/examples/example.typ#L85-L88

[example.pdf](https://github.com/touying-typ/touying/files/15283621/example.pdf)

cc @cooki35 @zouharvi @JuliusFreudenberger, maybe @laurmaedje for presentation mode for typst.app


Hope to have more feedback, thanks :-)