### PR TITLE
Update to typst 11

### DIFF
--- a/slide.typ
+++ b/slide.typ
@@ -557,29 +557,29 @@
   }
   let bodies = bodies.pos()
   // update pdfpc
-  let update-pdfpc(curr-subslide) = locate(loc => [
+  let update-pdfpc(curr-subslide) = context [
     #metadata((t: "NewSlide")) <pdfpc>
-    #metadata((t: "Idx", v: loc.page() - 1)) <pdfpc>
+    #metadata((t: "Idx", v: here().page() - 1)) <pdfpc>
     #metadata((t: "Overlay", v: curr-subslide - 1)) <pdfpc>
-    #metadata((t: "LogicalSlide", v: states.slide-counter.at(loc).first())) <pdfpc>
-  ])
-  let page-preamble(curr-subslide) = locate(loc => {
+    #metadata((t: "LogicalSlide", v: states.slide-counter.get().first())) <pdfpc>
+  ]
+  let page-preamble(curr-subslide) = context {
     if self.reset-footnote {
       counter(footnote).update(0)
     }
-    if loc.page() == self.first-slide-number {
+    if here().page() == self.first-slide-number {
       // preamble
       utils.call-or-display(self, self.preamble)
       // pdfpc slide markers
       if self.pdfpc-file {
-        pdfpc.pdfpc-file(loc)
+        pdfpc.pdfpc-file(here())
       }
     }
     utils.call-or-display(self, self.page-preamble)
     if curr-subslide == 1 and title != none {
       utils.bookmark(level: 3, title)
     }
-  })
+  }
   // update states
   let _update-states(repetitions) = {
     // 1. slide counter part

--- a/themes/aqua.typ
+++ b/themes/aqua.typ
@@ -143,7 +143,7 @@
 #let register(
   self: s,
   aspect-ratio: "16-9",
-  footer: states.slide-counter.display(),
+    footer: context { states.slide-counter.display() },
   lang: "en",
   ..args,
 ) = {

--- a/themes/dewdrop.typ
+++ b/themes/dewdrop.typ
@@ -234,7 +234,7 @@
   sidebar: (width: 10em),
   mini-slides: (height: 4em, x: 2em, section: false, subsection: true),
   footer: [],
-  footer-right: states.slide-counter.display() + " / " + states.last-slide-number,
+    footer-right: context { states.slide-counter.display() + " / " + states.last-slide-number },
   primary: rgb("#0c4842"),
   alpha: 70%,
   ..args,

--- a/themes/metropolis.typ
+++ b/themes/metropolis.typ
@@ -117,7 +117,7 @@
   aspect-ratio: "16-9",
   header: states.current-section-with-numbering,
   footer: [],
-  footer-right: states.slide-counter.display() + " / " + states.last-slide-number,
+    footer-right: context { states.slide-counter.display() + " / " + states.last-slide-number },
   footer-progress: true,
   ..args,
 ) = {

--- a/themes/simple.typ
+++ b/themes/simple.typ
@@ -45,7 +45,7 @@
   self: s,
   aspect-ratio: "16-9",
   footer: [],
-  footer-right: states.slide-counter.display() + " / " + states.last-slide-number,
+    footer-right: context { states.slide-counter.display() + " / " + states.last-slide-number },
   background: rgb("#ffffff"),
   foreground: rgb("#000000"),
   primary: aqua.darken(50%),

--- a/themes/university.typ
+++ b/themes/university.typ
@@ -178,7 +178,7 @@
   footer-columns: (25%, 1fr, 25%),
   footer-a: self => self.info.author,
   footer-b: self => if self.info.short-title == auto { self.info.title } else { self.info.short-title },
-  footer-c: self => {
+  footer-c: self => context {
     h(1fr)
     utils.info-date(self)
     h(1fr)

--- a/utils/pdfpc.typ
+++ b/utils/pdfpc.typ
@@ -2,7 +2,7 @@
 // Author: Andreas Kröpelin
 
 #let pdfpc-file(loc) = {
-  let arr = query(<pdfpc>, loc).map(it => it.value)
+  let arr = query(<pdfpc>).map(it => it.value)
   let (config, ..slides) = arr.split((t: "NewSlide"))
   let pdfpc = (
     pdfpcFormat: 2,

--- a/utils/states.typ
+++ b/utils/states.typ
@@ -1,16 +1,16 @@
 // touying slide counters
 #let slide-counter = counter("touying-slide-counter")
 #let last-slide-counter = counter("touying-last-slide-counter")
-#let last-slide-number = locate(loc => last-slide-counter.final(loc).first())
+#let last-slide-number = context { last-slide-counter.final().first() }
 
-#let touying-progress(callback) = locate(loc => {
-  if last-slide-counter.final(loc).first() == 0 {
+#let touying-progress(callback) = context {
+  if last-slide-counter.final().first() == 0 {
     callback(1.0)
     return
   }
-  let ratio = calc.min(1.0, slide-counter.at(loc).first() / last-slide-counter.final(loc).first())
+  let ratio = calc.min(1.0, slide-counter.get().first() / last-slide-counter.final().first())
   callback(ratio)
-})
+}
 
 // sections
 #let sections-state = state("touying-sections-state", ((kind: "section", title: none, short-title: none, loc: none, count: 0, children: ()),))
@@ -21,16 +21,18 @@
 // slide note state
 #let slide-note-state = state("touying-slide-note-state", none)
 
-#let _new-section(short-title: auto, duplicate: false, title) = locate(loc => {
+#let _new-section(short-title: auto, duplicate: false, title) = context {
+  let loc = here()
   sections-state.update(sections => {
     if duplicate or sections.last().title != title or sections.last().short-title != short-title {
       sections.push((kind: "section", title: title, short-title: short-title, loc: loc, count: 0, children: ()))
     }
     sections
   })
-})
+}
 
-#let _new-subsection(short-title: auto, duplicate: false, title) = locate(loc => {
+#let _new-subsection(short-title: auto, duplicate: false, title) = context {
+  let loc = here()
   sections-state.update(sections => {
     let last-section = sections.pop()
     let last-subsection = (kind: "none")
@@ -45,9 +47,10 @@
     sections.push(last-section)
     sections
   })
-})
+}
 
-#let _sections-step(repetitions) = locate(loc => {
+#let _sections-step(repetitions) = context {
+  let loc = here()
   sections-state.update(sections => {
     let last-section = sections.pop()
     if last-section.children.len() == 0 or last-section.children.last().kind == "slide" {
@@ -65,11 +68,11 @@
     }
     sections
   }
-)})
+)}
 
-#let touying-final-sections(callback) = locate(loc => {
-  callback(sections-state.final(loc))
-})
+#let touying-final-sections(callback) = context {
+  callback(sections-state.final())
+}
 
 #let touying-outline(self: none, func: enum, enum-args: (:), list-args: (:), padding: 0pt) = touying-final-sections(sections => {
   let enum-args = (full: true) + enum-args
@@ -90,65 +93,65 @@
   ))
 })
 
-#let current-section-title = locate(loc => {
-  let sections = sections-state.at(loc)
+#let current-section-title = context {
+  let sections = sections-state.get()
   sections.last().title
-})
+}
 
-#let current-subsection-title = locate(loc => {
-  let sections = sections-state.at(loc)
+#let current-subsection-title = context {
+  let sections = sections-state.get()
   let subsections = sections.last().children.filter(v => v.kind == "subsection")
   if subsections.len() > 0 {
     subsections.last().title
   } else {
     none
   }
-})
+}
 
 #let current-slide-title = context slide-title-state.get()
 
 #let current-slide-note = context slide-note-state.get()
 
 #let _typst-numbering = numbering
-#let current-section-number(numbering: "01", ignore-zero: true) = locate(loc => {
-  let sections = sections-state.at(loc)
+#let current-section-number(numbering: "01", ignore-zero: true) = context {
+  let sections = sections-state.get()
   if not ignore-zero or sections.len() - 1 != 0 {
     _typst-numbering(numbering, sections.len() - 1)
   }
-})
+}
 
-#let current-section-with-numbering(self, ignore-zero: true) = locate(loc => {
-  let sections = sections-state.at(loc)
+#let current-section-with-numbering(self, ignore-zero: true) = context {
+  let sections = sections-state.get()
   if self.numbering != none and (not ignore-zero or sections.len() - 1 != 0) {
     _typst-numbering(self.numbering, sections.len() - 1)
     [ ]
   }
   sections.last().title
-})
+}
 
-#let current-subsection-number(numbering: "1.1", ignore-zero: true) = locate(loc => {
-  let sections = sections-state.at(loc)
+#let current-subsection-number(numbering: "1.1", ignore-zero: true) = context {
+  let sections = sections-state.get()
   let subsections = sections.last().children
   if (not ignore-zero or sections.len() - 1 != 0) and (not ignore-zero or subsections.len() - 1 != 0) {
     _typst-numbering(numbering, sections.len() - 1, subsections.len() - 1)
   }
-})
+}
 
-#let current-subsection-with-numbering(self, ignore-zero: true) = locate(loc => {
-  let sections = sections-state.at(loc)
+#let current-subsection-with-numbering(self, ignore-zero: true) = context {
+  let sections = sections-state.get()
   let subsections = sections.last().children
   if self.numbering != none and (not ignore-zero or sections.len() - 1 != 0) and (not ignore-zero or subsections.len() - 1 != 0) {
     _typst-numbering(self.numbering, sections.len() - 1, subsections.len() - 1)
     [ ]
   }
   subsections.last().title
-})
+}
 
-#let touying-progress-with-sections(callback) = locate(loc => {
+#let touying-progress-with-sections(callback) = context {
   callback((
-    current-sections: sections-state.at(loc),
-    final-sections: sections-state.final(loc),
-    current-slide-number: slide-counter.at(loc).first(),
-    last-slide-number: last-slide-counter.final(loc).first(),
+    current-sections: sections-state.get(),
+    final-sections: sections-state.final(),
+    current-slide-number: slide-counter.get().first(),
+    last-slide-number: last-slide-counter.final().first(),
   ))
-})
+}

--- a/utils/utils.typ
+++ b/utils/utils.typ
@@ -223,12 +223,12 @@
 // Attribution: This file is based on the code from https://github.com/andreasKroepelin/polylux/pull/91
 // Author: ntjess
 
-#let _size-to-pt(size, styles, container-dimension) = {
+#let _size-to-pt(size, container-dimension) = {
   let to-convert = size
   if type(size) == "ratio" {
     to-convert = container-dimension * size
   }
-  measure(v(to-convert), styles).height
+  measure(v(to-convert)).height
 }
 
 #let _limit-content-width(width: none, body, container-size, styles) = {
@@ -323,28 +323,26 @@
 }
 
 #let fit-to-width(grow: true, shrink: true, width, content) = {
-  style(styles => {
-    layout(layout-size => {
-      let content-size = measure(content, styles)
-      let content-width = content-size.width
-      let width = _size-to-pt(width, styles, layout-size.width)
-      if (
-        content-width != 0pt and
-        ((shrink and (width < content-width))
-        or (grow and (width > content-width)))
-      ) {
-        let ratio = width / content-width * 100%
-        // The first box keeps content from prematurely wrapping
-        let scaled = scale(
-          box(content, width: content-width), origin: top + left, x: ratio, y: ratio
-        )
-        // The second box lets typst know the post-scaled dimensions, since `scale`
-        // doesn't update layout information
-        box(scaled, width: width, height: content-size.height * ratio)
-      } else {
-        content
-      }
-    })
+  layout(layout-size => {
+    let content-size = measure(content)
+    let content-width = content-size.width
+    let width = _size-to-pt(width, layout-size.width)
+    if (
+      content-width != 0pt and
+      ((shrink and (width < content-width))
+      or (grow and (width > content-width)))
+    ) {
+      let ratio = width / content-width * 100%
+      // The first box keeps content from prematurely wrapping
+      let scaled = scale(
+        box(content, width: content-width), origin: top + left, x: ratio, y: ratio
+      )
+      // The second box lets typst know the post-scaled dimensions, since `scale`
+      // doesn't update layout information
+      box(scaled, width: width, height: content-size.height * ratio)
+    } else {
+      content
+    }
   })
 }
 
@@ -361,10 +359,10 @@
   }
 
   let to-display = layout(layout-size => {
-    style(styles => {
-      let body-size = measure(body, styles)
+    context {
+      let body-size = measure(body)
       let bounding-width = calc.min(body-size.width, layout-size.width)
-      let wrapped-body-size = measure(box(body, width: bounding-width), styles)
+      let wrapped-body-size = measure(box(body, width: bounding-width))
       let named = cover-args.named()
       if "width" not in named {
         named.insert("width", wrapped-body-size.width)
@@ -387,7 +385,7 @@
         body,
         rect(fill: fill, ..named, ..cover-args.pos())
       )
-    })
+    }
   })
   if inline {
     box(to-display)
@@ -509,8 +507,8 @@
 
   let subslides = subslides-contents.map(it => it.first())
   let contents = subslides-contents.map(it => it.last())
-  style(styles => {
-    let sizes = contents.map(c => measure(c, styles))
+  context {
+    let sizes = contents.map(c => measure(c))
     let max-width = calc.max(..sizes.map(sz => sz.width))
     let max-height = calc.max(..sizes.map(sz => sz.height))
     for (subslides, content) in subslides-contents {
@@ -520,7 +518,7 @@
         align(position, content)
       ))
     }
-  })
+  }
 }
 
 #let alternatives(


### PR DESCRIPTION
This PR updates touying to typst 11, removing calls to `style` and `locate` and thereby removing deprecation warnings.