### PR TITLE
fix: Allow a `content` to have no `body`

### DIFF
--- a/src/core.typ
+++ b/src/core.typ
@@ -1121,7 +1121,8 @@
           need-cover: repetitions <= index,
           base: repetitions,
           index: index,
-          child.body,
+          // Some functions (e.g. square) may have no body
+          child.at("body", default: none),
         )
         let cont = conts.first()
         if repetitions <= index or not need-cover {


### PR DESCRIPTION
Fixes #73

## An example

```typst
#import "lib.typ": themes
#import themes.simple: simple-theme

#show: simple-theme.with(aspect-ratio: "16-9")

#square()
```