### PR TITLE
fix: fix no alert in table cells 

### DIFF
--- a/src/core.typ
+++ b/src/core.typ
@@ -910,14 +910,15 @@
         let kind = it.body.value.at("kind", default: none)
         if kind == "touying-pause" {
           repetitions += 1
+          continue
         } else if kind == "touying-meanwhile" {
           // reset the repetitions
           max-repetitions = calc.max(max-repetitions, repetitions)
           repetitions = 1
+          continue
         }
       }
-    }
-    // if it is a function, then call it with self
+    }    // if it is a function, then call it with self
     if type(it) == function {
       // subslide index
       it = it(self)

--- a/src/core.typ
+++ b/src/core.typ
@@ -918,7 +918,8 @@
           continue
         }
       }
-    }    // if it is a function, then call it with self
+    }
+    // if it is a function, then call it with self
     if type(it) == function {
       // subslide index
       it = it(self)

--- a/src/core.typ
+++ b/src/core.typ
@@ -915,7 +915,6 @@
           max-repetitions = calc.max(max-repetitions, repetitions)
           repetitions = 1
         }
-        continue
       }
     }
     // if it is a function, then call it with self


### PR DESCRIPTION
Solve https://github.com/touying-typ/touying/issues/77

Previous, the items in cells will be omitted due to `continue`.

I am not quite familiar with the code. If it has conflicts with other exist functions, maybe we could add a `if` instead? 
Like
```
if kind !="touying-fn-wrapper" {
          continue
        }
```