### PR TITLE
feat: add `linebreaks` option to components.mini-slides

### DIFF
--- a/src/components.typ
+++ b/src/components.typ
@@ -355,6 +355,8 @@
 /// - `display-section` is a boolean indicating whether the sections should be displayed. Default is `false`.
 ///
 /// - `display-subsection` is a boolean indicating whether the subsections should be displayed. Default is `true`.
+/// 
+/// - `linebreaks` is a boolean indicating whether or not to insert linebreaks between links for sections and subsections
 ///
 /// - `short-heading` is a boolean indicating whether the headings should be shortened. Default is `true`.
 #let mini-slides(
@@ -363,6 +365,7 @@
   alpha: 60%,
   display-section: false,
   display-subsection: true,
+  linebreaks: true,
   short-heading: true,
 ) = (
   context {
@@ -414,7 +417,7 @@
               }
             }
           }
-          if display-section and display-subsection {
+          if display-section and display-subsection and linebreaks {
             linebreak()
           }
         })
@@ -435,7 +438,7 @@
               }
             }
           }
-          if display-subsection {
+          if display-subsection and linebreaks {
             linebreak()
           }
         })

--- a/themes/dewdrop.typ
+++ b/themes/dewdrop.typ
@@ -37,6 +37,7 @@
       alpha: self.store.alpha,
       display-section: self.store.mini-slides.at("display-section", default: false),
       display-subsection: self.store.mini-slides.at("display-subsection", default: true),
+      linebreaks: self.store.mini-slides.at("linebreaks", default: true),
       short-heading: self.store.mini-slides.at("short-heading", default: true),
     )
   }
@@ -259,11 +260,12 @@
 ///   - `indent` is the indent of the outline in the sidebar.
 ///   - `short-heading` is whether the outline in the sidebar is short.
 ///
-/// - `mini-slides` is the configuration of the mini-slides. You can set the height, x, display-section, display-subsection, and short-heading of the mini-slides. Default is `(height: 4em, x: 2em, display-section: false, display-subsection: true, short-heading: true)`.
+/// - `mini-slides` is the configuration of the mini-slides. You can set the height, x, display-section, display-subsection, and short-heading of the mini-slides. Default is `(height: 4em, x: 2em, display-section: false, display-subsection: true, linebreaks: true, short-heading: true)`.
 ///   - `height` is the height of the mini-slides.
 ///   - `x` is the x of the mini-slides.
 ///   - `display-section` is whether the slides of section is displayed in the mini-slides.
-///   - `display-subsection` is whether we add linebreak between subsections.
+///   - `display-subsection` is whether the slides of subsections is displayed in the mini-slides.
+///   - `linebreaks` is whether or linebreaks are in between links for sections and subsections in the mini-slides.
 ///   - `short-heading` is whether the mini-slides is short. Default is `true`.
 ///
 /// - `footer` is the footer of the slides. Default is `none`.
@@ -295,7 +297,7 @@
   aspect-ratio: "16-9",
   navigation: "sidebar",
   sidebar: (width: 10em, filled: false, numbered: false, indent: .5em, short-heading: true),
-  mini-slides: (height: 4em, x: 2em, display-section: false, display-subsection: true, short-heading: true),
+  mini-slides: (height: 4em, x: 2em, display-section: false, display-subsection: true, linebreaks: true, short-heading: true),
   footer: none,
   footer-right: context utils.slide-counter.display() + " / " + utils.last-slide-number,
   primary: rgb("#0c4842"),


### PR DESCRIPTION
I was rather disappointed when, trying to disable linebreaks in the minipages of the `dewdrop` theme, the option for it did not seem to function as described:

>  -  `display-subsection` is whether we add linebreak between subsections.

In actuality, this option (as the doc for `mini-slides` describes) just enables/disables circles for subsection slides.

In this PR, I fixed the documentation and implemented the `linebreaks` feature that adds the behaviour I was looking for:

| `linebreaks: true` | `linebreaks: false` |
|------------------|------------------|
| ![image](https://github.com/user-attachments/assets/9be696e5-e800-4fc7-b182-ac1e05a492b9) |![image](https://github.com/user-attachments/assets/e461b232-7bf4-4725-9d8a-f38808788b4f) |
