### PR TITLE
Also hide `enum` numbers with `show-hide-set-list-marker-none`

### DIFF
--- a/src/magic.typ
+++ b/src/magic.typ
@@ -108,7 +108,12 @@
 ///
 /// Usage: `#show: show-hide-set-list-marker-none`
 #let show-hide-set-list-marker-none(body) = {
-  show hide: set list(marker: none)
+  show hide: it => {
+    set list(marker: none)
+    set enum(numbering: n => [])
+
+    it
+  }
   body
 }
 


### PR DESCRIPTION
Fixes #10

Previously, the `show-hide-set-list-marker-none` hack only fixes lists, but enum numbers were still visible.