### PR TITLE
fix progress bar not to break apart

### DIFF
--- a/src/components.typ
+++ b/src/components.typ
@@ -75,6 +75,7 @@
   grid(
     columns: (ratio * 100%, 1fr),
     rows: height,
+    gutter: 0pt,
     cell(fill: primary), cell(fill: secondary),
   )
 })
@@ -355,7 +356,7 @@
 /// - `display-section` is a boolean indicating whether the sections should be displayed. Default is `false`.
 ///
 /// - `display-subsection` is a boolean indicating whether the subsections should be displayed. Default is `true`.
-/// 
+///
 /// - `linebreaks` is a boolean indicating whether or not to insert linebreaks between links for sections and subsections
 ///
 /// - `short-heading` is a boolean indicating whether the headings should be shortened. Default is `true`.


### PR DESCRIPTION
I found an issue with the rendering of progress bars in the section slides. I have added a single line of code to prevent this problem.

Thank you for considering my contribution. Feel free to use or modify it as needed!

## minimal example
```typst
#import "@preview/touying:0.5.3": *
#import themes.metropolis: *
#show: metropolis-theme
#set grid(gutter: 1em)

= First chapter
= Second chapter
```

This is how the example above renders in typst.app.
You may see the progress bar is broken in the first chapter title slide.
![image](https://github.com/user-attachments/assets/905877d0-6587-48d4-8179-1f148de43524)