### PR TITLE
Fix frozen-counters bug with multiple #pause commands

### DIFF
--- a/src/core.typ
+++ b/src/core.typ
@@ -1650,15 +1650,18 @@
     }
     [#metadata((kind: "touying-new-subslide")) <touying-metadata>]
     if self.at("enable-frozen-states-and-counters", default: true) and not self.handout and self.repeat > 1 {
-      context {
-        let loc-new-slide = query(selector(<touying-metadata>).before(here()))
-          .filter(it => it.value.kind == "touying-new-slide")
-          .last()
-          .location()
-        _rewind-states(self.frozen-states, loc-new-slide)
-        _rewind-states(self.default-frozen-states, loc-new-slide)
-        _rewind-states(self.frozen-counters, loc-new-slide)
-        _rewind-states(self.default-frozen-counters, loc-new-slide)
+      if self.subslide == 1 {
+        context {
+          utils.loc-prior-newslide.update(here())
+        }
+      } else {
+        context {
+          let loc-prior-newslide = utils.loc-prior-newslide.get()
+          _rewind-states(self.frozen-states, loc-prior-newslide)
+          _rewind-states(self.default-frozen-states, loc-prior-newslide)
+          _rewind-states(self.frozen-counters, loc-prior-newslide)
+          _rewind-states(self.default-frozen-counters, loc-prior-newslide)
+        }
       }
     }
     utils.call-or-display(self, self.at("subslide-preamble", default: none))

--- a/src/core.typ
+++ b/src/core.typ
@@ -1650,14 +1650,16 @@
     }
     [#metadata((kind: "touying-new-subslide")) <touying-metadata>]
     if self.at("enable-frozen-states-and-counters", default: true) and not self.handout and self.repeat > 1 {
-      let loc-new-slide = query(selector(<touying-metadata>).before(here()))
-        .filter(it => it.value.kind == "touying-new-slide")
-        .last()
-        .location()
-      _rewind-states(self.frozen-states, loc-new-slide)
-      _rewind-states(self.default-frozen-states, loc-new-slide)
-      _rewind-states(self.frozen-counters, loc-new-slide)
-      _rewind-states(self.default-frozen-counters, loc-new-slide)
+      context {
+        let loc-new-slide = query(selector(<touying-metadata>).before(here()))
+          .filter(it => it.value.kind == "touying-new-slide")
+          .last()
+          .location()
+        _rewind-states(self.frozen-states, loc-new-slide)
+        _rewind-states(self.default-frozen-states, loc-new-slide)
+        _rewind-states(self.frozen-counters, loc-new-slide)
+        _rewind-states(self.default-frozen-counters, loc-new-slide)
+      }
     }
     utils.call-or-display(self, self.at("subslide-preamble", default: none))
     utils.call-or-display(self, self.at("default-subslide-preamble", default: none))

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -55,6 +55,9 @@
 #let slide-note-state = state("touying-slide-note-state", none)
 #let current-slide-note = context slide-note-state.get()
 
+// state to store the location of the newslide for handling frozen states
+#let loc-prior-newslide = state("touying-loc-prior-newslide", none)
+
 
 /// Remove leading and trailing empty elements from an array of content
 ///

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -55,15 +55,6 @@
 #let slide-note-state = state("touying-slide-note-state", none)
 #let current-slide-note = context slide-note-state.get()
 
-// -------------------------------------
-// Saved states and counters
-// -------------------------------------
-
-#let saved-frozen-states = state("touying-saved-frozen-states", ())
-#let saved-default-frozen-states = state("touying-saved-default-frozen-states", ())
-#let saved-frozen-counters = state("touying-saved-frozen-counters", ())
-#let saved-default-frozen-counters = state("touying-saved-default-frozen-counters", ())
-
 
 /// Remove leading and trailing empty elements from an array of content
 ///


### PR DESCRIPTION
## Description

This PR addresses a bug in the frozen-counters functionality where status updates show unexpected behavior when using multiple `#pause` commands. This issue may be related to #72.

## Problem

When using multiple `#pause` commands, figure captions are not correctly incremented. For example, in the example below with multiple figures and pauses, the final figure might be captioned as "Figure 2:" though it should be "Figure 3:".

```typst
#import "@preview/touying:0.5.3": *
#import themes.simple: *

#show: simple-theme

== slide 1
#figure([test figure], caption: [caption])

== slide 2
#figure([test figure], caption: [caption])
#pause
paused

== slide 3
#figure([test figure], caption: [caption])
#pause
paused

```

## Solution

Instead of storing the counter value at the beginning of a sequence of subslides, we now store the location. We then use `status.at(location)` to rewind the status when needed. This approach ensures that counters are correctly updated across pauses and slides.

## Testing

I have tested my code with examples given in the examples folder in this repository, besides the example above, and two examples in #72. All of them compiled with no errors / warnings.

---

- As I'm not fluent in Typst, my code might not be fully ideomatic. I welcome any revisions or improvements to the implementation.
- It might be better to store the location in some outer variable (e.g. `#utils.current-slide`) and update it when creating a new slide, instead of querying the label for every new subslide.
- minor fix: I found a variable named `current`, which is not used, so I deleted it.
