### PR TITLE
fix: incorrect page num when draft is true

### DIFF
--- a/src/core.typ
+++ b/src/core.typ
@@ -1687,7 +1687,7 @@
     [#metadata((kind: "touying-new-page")) <touying-metadata>]
     // 1. slide counter part
     //    if freeze-slide-counter is false, then update the slide-counter
-    if self.subslide == 1 {
+    if self.handout or self.subslide == 1 {
       if not self.at("freeze-slide-counter", default: false) {
         utils.slide-counter.step()
         //  if appendix is false, then update the last-slide-counter
@@ -1719,6 +1719,7 @@
   let page-extra-args = _get-page-extra-args(self)
 
   if self.handout {
+    self.subslide = repeat
     let (conts, _, _) = _parse-content-into-results-and-repetitions(
       self: self,
       index: repeat,

--- a/src/core.typ
+++ b/src/core.typ
@@ -1719,7 +1719,6 @@
   let page-extra-args = _get-page-extra-args(self)
 
   if self.handout {
-    self.subslide = repeat
     let (conts, _, _) = _parse-content-into-results-and-repetitions(
       self: self,
       index: repeat,


### PR DESCRIPTION
I removed one line to correctly handle page numbering when draft mode is true. This change resolves issue #121.
I've tested it to ensure pagination works as expected in draft mode with the example given in #121.
Ready for review!