### PR TITLE
fix: metropolis slide's header to return content if title is specified

### DIFF
--- a/themes/metropolis.typ
+++ b/themes/metropolis.typ
@@ -52,7 +52,7 @@
     components.left-and-right(
       {
         if title != auto {
-          utils.fit-to-width.with(grow: false, 100%, title)
+          utils.fit-to-width(grow: false, 100%, title)
         } else {
           utils.call-or-display(self, self.store.header)
         }


### PR DESCRIPTION
I discovered a bug in the metropolis theme where the header was returning the function itself instead of calling it. This causes an error when trying to specify the slide title.

## minimal working example

```typst
#import "@preview/touying:0.5.3": *
#import themes.metropolis: *

#show: metropolis-theme

#slide(title: "section with a title")[
  error!
]
```