### PR TITLE
feat: add cover color-changing-cover

### DIFF
--- a/src/utils.typ
+++ b/src/utils.typ
@@ -816,6 +816,9 @@
   if it.has("base") {
     return _contains-text(it.base)
   }
+  if it.has("child") {
+    return _contains-text(it.child)
+  }
   if it.has("children") {
     for child in it.children {
       if _contains-text(child) {

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -803,7 +803,7 @@
 }
 
 // recursively checks if `it` has a text in it
-#let _contains-text(it) = {
+#let _contains-text(it, transparentize-table) = {
   if type(it) != content {
     return false
   }
@@ -811,17 +811,20 @@
     return true
   }
   if it.has("body") {
-    return _contains-text(it.body)
+    return _contains-text(it.body, transparentize-table)
   }
   if it.has("base") {
-    return _contains-text(it.base)
+    return _contains-text(it.base, transparentize-table)
   }
   if it.has("child") {
-    return _contains-text(it.child)
+    return _contains-text(it.child, transparentize-table)
   }
   if it.has("children") {
+    if it.func() == table and transparentize-table {
+      return true
+    }
     for child in it.children {
-      if _contains-text(child) {
+      if _contains-text(child, transparentize-table) {
         return true
       }
     }
@@ -829,8 +832,14 @@
   return false
 }
 
-#let color-changing-cover(self: none, color: gray, fallback-hide: true, it) = {
-  if _contains-text(it) {
+#let color-changing-cover(
+  self: none,
+  color: gray,
+  fallback-hide: true,
+  transparentize-table: false,
+  it,
+) = {
+  if _contains-text(it, transparentize-table) {
     set text(color)
     show text: set text(color)
     it
@@ -841,8 +850,14 @@
   }
 }
 
-#let alpha-changing-cover(self: none, ratio: 75%, fallback-hide: true, it) = context {
-  if _contains-text(it) {
+#let alpha-changing-cover(
+  self: none,
+  ratio: 75%,
+  fallback-hide: true,
+  transparentize-table: false,
+  it,
+) = context {
+  if _contains-text(it, transparentize-table) {
     set text(text.fill.transparentize(ratio))
     show text: it => context {
       text(update-alpha(text.fill, 100% - ratio), it)

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -820,8 +820,8 @@
     return _contains-text(it.child, transparentize-table)
   }
   if it.has("children") {
-    if it.func() == table and transparentize-table {
-      return true
+    if it.func() == table {
+      return transparentize-table
     }
     for child in it.children {
       if _contains-text(child, transparentize-table) {

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -841,6 +841,17 @@
   }
 }
 
+#let alpha-changing-cover(self: none, ratio: 80%, fallback-hide: true, it) = context {
+  if _contains-text(it) {
+    set text(text.fill.transparentize(ratio))
+    show text: set text(text.fill.transparentize(ratio))
+    it
+  } else if fallback-hide {
+    hide(it)
+  } else {
+    it
+  }
+}
 
 /// Alert content with a primary color.
 ///

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -826,7 +826,7 @@
   return false
 }
 
-#let make-color-cover-with(color) = {
+#let make-color-cover-with(color, fallback-hide) = {
   let inner(it) = {
     if is-sequence(it) {
       // recursively hides contents
@@ -838,15 +838,21 @@
       show it.func(): set text(fill: color)
       it
     } else {
-      // use `hide` as a fallback, so figures, images, tables... will be completely hidden.
-      // we may use the cover-with-rect instead.
-      hide(it)
+      if fallback-hide {
+        // use `hide` as a fallback, so figures, images, tables... will be completely hidden.
+        // we may use the cover-with-rect instead.
+        hide(it)
+      } else {
+        it
+      }
     }
   }
   return inner
 }
 
-#let color-changing-cover(color: gray) = method-wrapper(make-color-cover-with(color))
+#let color-changing-cover(color: gray, fallback-hide: true) = method-wrapper(
+  make-color-cover-with(color, fallback-hide),
+)
 
 
 /// Alert content with a primary color.

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -841,10 +841,12 @@
   }
 }
 
-#let alpha-changing-cover(self: none, ratio: 80%, fallback-hide: true, it) = context {
+#let alpha-changing-cover(self: none, ratio: 75%, fallback-hide: true, it) = context {
   if _contains-text(it) {
     set text(text.fill.transparentize(ratio))
-    show text: set text(text.fill.transparentize(ratio))
+    show text: it => context {
+      text(update-alpha(text.fill, 100% - ratio), it)
+    }
     it
   } else if fallback-hide {
     hide(it)

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -785,7 +785,7 @@
 /// - alpha (float): The new alpha value.
 ///
 /// -> color
-#let update-alpha(constructor: rgb, color, alpha) = constructor(..color.components(alpha: true).slice(0, -1), alpha)
+#let update-alpha(color, alpha) = color.opacify(100%).transparentize(100% - alpha)
 
 
 /// Cover content with a transparent rectangle.
@@ -852,15 +852,15 @@
 
 #let alpha-changing-cover(
   self: none,
-  ratio: 75%,
+  alpha: 25%,
   fallback-hide: true,
   transparentize-table: false,
   it,
 ) = context {
   if _contains-text(it, transparentize-table) {
-    set text(text.fill.transparentize(ratio))
+    set text(text.fill.transparentize(100% - alpha))
     show text: it => context {
-      text(update-alpha(text.fill, 100% - ratio), it)
+      text(update-alpha(text.fill, alpha), it)
     }
     it
   } else if fallback-hide {

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -822,7 +822,6 @@
         return true
       }
     }
-    return false
   }
   return false
 }
@@ -835,10 +834,12 @@
         inner(child)
       }
     } else if _contains-text(it) {
+      // if `it` contains a text, update the color.
       show it.func(): set text(fill: color)
       it
     } else {
-      // use `hide` as a fallback
+      // use `hide` as a fallback, so figures, images, tables... will be completely hidden.
+      // we may use the cover-with-rect instead.
       hide(it)
     }
   }

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -802,7 +802,7 @@
   )
 }
 
-
+// recursively checks if `it` has a text in it
 #let _contains-text(it) = {
   if type(it) != content {
     return false
@@ -826,33 +826,17 @@
   return false
 }
 
-#let make-color-cover-with(color, fallback-hide) = {
-  let change-color(it) = {
-    if is-sequence(it) {
-      // recursively hides contents
-      for child in it.children {
-        change-color(child)
-      }
-    } else if _contains-text(it) {
-      // if `it` contains a text, update the color.
-      show it.func(): set text(fill: color)
-      it
-    } else {
-      if fallback-hide {
-        // use `hide` as a fallback, so figures, images, tables... will be completely hidden.
-        // we may use the cover-with-rect instead.
-        hide(it)
-      } else {
-        it
-      }
-    }
+#let color-changing-cover(self: none, color: gray, fallback-hide: true, it) = {
+  if _contains-text(it) {
+    set text(color)
+    show text: set text(color)
+    it
+  } else if fallback-hide {
+    hide(it)
+  } else {
+    it
   }
-  return change-color
 }
-
-#let color-changing-cover(color: gray, fallback-hide: true) = method-wrapper(
-  make-color-cover-with(color, fallback-hide),
-)
 
 
 /// Alert content with a primary color.

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -803,6 +803,51 @@
 }
 
 
+#let _contains-text(it) = {
+  if type(it) != content {
+    return false
+  }
+  if it.func() == text {
+    return true
+  }
+  if it.has("body") {
+    return _contains-text(it.body)
+  }
+  if it.has("base") {
+    return _contains-text(it.base)
+  }
+  if it.has("children") {
+    for child in it.children {
+      if _contains-text(child) {
+        return true
+      }
+    }
+    return false
+  }
+  return false
+}
+
+#let make-color-cover-with(color) = {
+  let inner(it) = {
+    if is-sequence(it) {
+      // recursively hides contents
+      for child in it.children {
+        inner(child)
+      }
+    } else if _contains-text(it) {
+      show it.func(): set text(fill: color)
+      it
+    } else {
+      // use `hide` as a fallback
+      hide(it)
+    }
+  }
+  return inner
+}
+
+#let color-changing-cover(color: gray) = method-wrapper(make-color-cover-with(color))
+
+
 /// Alert content with a primary color.
 ///
 /// Example: `config-methods(alert: utils.alert-with-primary-color)`

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -827,11 +827,11 @@
 }
 
 #let make-color-cover-with(color, fallback-hide) = {
-  let inner(it) = {
+  let change-color(it) = {
     if is-sequence(it) {
       // recursively hides contents
       for child in it.children {
-        inner(child)
+        change-color(child)
       }
     } else if _contains-text(it) {
       // if `it` contains a text, update the color.
@@ -847,7 +847,7 @@
       }
     }
   }
-  return inner
+  return change-color
 }
 
 #let color-changing-cover(color: gray, fallback-hide: true) = method-wrapper(


### PR DESCRIPTION
This pull request introduces a new (pseudo) semitransparent cover function that provides a method for hiding content in slides. The function changes the text color of elements to a specified color if they contain text. If an element does not contain text, it can use `hide` as a fallback.

This implementation has been successfully tested with the default examples and the specific example provided in issue #112.