### PR TITLE
fix: respect colors dict in metropolis theme

### DIFF
--- a/themes/metropolis.typ
+++ b/themes/metropolis.typ
@@ -174,7 +174,7 @@
     stack(
       dir: ttb,
       spacing: 1em,
-      utils.display-current-heading(level: level, numbered: numbered),
+      text(self.colors.neutral-darkest, utils.display-current-heading(level: level, numbered: numbered)),
       block(
         height: 2pt,
         width: 100%,
@@ -182,7 +182,7 @@
         components.progress-bar(height: 2pt, self.colors.primary, self.colors.primary-light),
       ),
     )
-    body
+    text(self.colors.neutral-dark, body)
   }
   self = utils.merge-dicts(
     self,


### PR DESCRIPTION
Let `new-section-slide` of Metropolis theme respect `self.colors` to fix [this bug](https://forum.typst.app/t/touying-metropolis-theme-what-is-the-variable-to-define-the-color-of-titles-in-section-slides/1992/1).