### PR TITLE
fix: show-hide-set-list-marker-none with full enum

### DIFF
--- a/src/magic.typ
+++ b/src/magic.typ
@@ -122,7 +122,7 @@
 #let show-hide-set-list-marker-none(body) = {
   show hide: it => {
     set list(marker: none)
-    set enum(numbering: n => none)
+    set enum(numbering: (..nums) => none)
 
     it
   }


### PR DESCRIPTION
Animation effects such as `#pause` make `set enum(numbering: n => none)` throw an `unexpected argument` error when `#set enum(full: true)` is applied. This PR fixes that.