### PR TITLE
feat: Pass named arguments of side-by-side to grid.

### DIFF
--- a/src/components.typ
+++ b/src/components.typ
@@ -22,6 +22,7 @@
 ///
 /// -> content
 #let side-by-side(columns: auto, gutter: 1em, ..bodies) = {
+  let args = bodies.named()
   let bodies = bodies.pos()
   if bodies.len() == 1 {
     return bodies.first()
@@ -31,7 +32,7 @@
   } else {
     columns
   }
-  grid(columns: columns, gutter: gutter, ..bodies)
+  grid(columns: columns, gutter: gutter, ..args, ..bodies)
 }
 
 


### PR DESCRIPTION
The update to the side-by-side component passes the named arguments further down to the grid. This allows us to pass e.g., ```align:top``` to side-by-side and in turn to grid to align the columns.

Another example would be stroke:
```typst
#side-by-side(stroke: 1pt+red)[
Test123
][
Test1
Test2
Test3
]
````
Currently this would result in side-by-side ignoring the stroke argument.
With the fix the columns would have red borders.