### PR TITLE
feat: minislides can be displayed inline

### DIFF
--- a/src/components.typ
+++ b/src/components.typ
@@ -424,6 +424,8 @@
 ///
 /// - short-heading (boolean): Indicates whether the headings should be shortened. Default is `true`.
 ///
+/// - inline (boolean): Indicates whether the bullets are displayed right after the text, instead of breaking the line. Default is `false`.
+///
 /// -> content
 #let mini-slides(
   self: none,
@@ -433,6 +435,7 @@
   display-subsection: true,
   linebreaks: true,
   short-heading: true,
+  inline: false,
 ) = (
   context {
     let headings = query(heading.where(level: 1).or(heading.where(level: 2)))
@@ -470,7 +473,11 @@
             hd.body
           }
           [#link(hd.location(), body)<touying-link>]
-          linebreak()
+          if inline {
+            h(.5em)
+          } else {
+            linebreak()
+          }
           while (
             slides.len() > 0 and slides.at(0).location().page() < next-page
           ) {
@@ -542,7 +549,7 @@
         })
     }
     set align(top)
-    show: block.with(inset: (top: .5em, x: 2em))
+    show: block.with(inset: (top: .5em, x: if inline { 1em } else { 2em }))
     show linebreak: it => it + v(-1em)
     set text(size: .7em)
     grid(columns: cols.map(_ => auto).intersperse(1fr), ..cols.intersperse([]))

--- a/themes/dewdrop.typ
+++ b/themes/dewdrop.typ
@@ -47,6 +47,7 @@
       ),
       linebreaks: self.store.mini-slides.at("linebreaks", default: true),
       short-heading: self.store.mini-slides.at("short-heading", default: true),
+      inline: self.store.mini-slides.at("inline", default: false),
     )
   }
 }
@@ -326,6 +327,7 @@
 ///   - display-subsection (boolean): Whether the slides of subsections are displayed in the mini-slides.
 ///   - linebreaks (boolean): Whether line breaks are in between links for sections and subsections in the mini-slides.
 ///   - short-heading (boolean): Whether the mini-slides are short. Default is `true`.
+///   - inline (boolean): Whether the mini-slides are displayed right after the section or subsection link, or on a new line. Default is `false`.
 ///
 /// - footer (content, function): The footer of the slides. Default is `none`.
 ///


### PR DESCRIPTION
I was porting some Beamer theme to typst, and in the source theme I was using minislides, but the bullets were displayed right after the section title to save vertical space. I patched `mini-slides` locally, but I thought this feature might be interesting for other users too.

Here's the look I was after:

<img width="500" height="281" alt="20251026_19h51m36s_grim" src="https://github.com/user-attachments/assets/fc13d62c-9f50-4223-a925-bd421f5c0fb3" />

And here is how the dewdrop theme would look with `inline: true, linebreaks: false`:

<img width="500" height="281" alt="20251026_19h51m57s_grim" src="https://github.com/user-attachments/assets/c0118d89-2254-4a5e-a4cb-fe7598a157d2" />


I'm not very experienced with typst, so I'm looking for feedback on the change -- for example, I'm not convinced that two settings with similar name (`linebreaks` and `inline`) should exist for this, perhaps it should be better to have `linebreaks` be some sort of enum, like "always", "inline-subsections", "inline-all".

Let me know what you think and if this feature is interesting for touying.