### PR TITLE
fix: theorion package is broken with Typst 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ In fact, Touying provides various styles for writing slides. For example, the ab
 #import "@preview/cetz:0.4.1"
 #import "@preview/fletcher:0.5.8" as fletcher: node, edge
 #import "@preview/numbly:0.1.0": numbly
-#import "@preview/theorion:0.4.0": *
+#import "@preview/theorion:0.4.1": *
 #import cosmos.clouds: *
 #show: show-theorion
 

--- a/examples/example.typ
+++ b/examples/example.typ
@@ -3,7 +3,7 @@
 #import "@preview/cetz:0.4.1"
 #import "@preview/fletcher:0.5.8" as fletcher: edge, node
 #import "@preview/numbly:0.1.0": numbly
-#import "@preview/theorion:0.4.0": *
+#import "@preview/theorion:0.4.1": *
 #import cosmos.clouds: *
 #show: show-theorion
 

--- a/tests/examples/example/test.typ
+++ b/tests/examples/example/test.typ
@@ -3,7 +3,7 @@
 #import "@preview/cetz:0.4.1"
 #import "@preview/fletcher:0.5.8" as fletcher: edge, node
 #import "@preview/numbly:0.1.0": numbly
-#import "@preview/theorion:0.4.0": *
+#import "@preview/theorion:0.4.1": *
 #import cosmos.clouds: *
 #show: show-theorion
 

--- a/tests/integration/theorion/test.typ
+++ b/tests/integration/theorion/test.typ
@@ -1,6 +1,6 @@
 #import "/lib.typ": *
 #import themes.university: *
-#import "@preview/theorion:0.4.0": *
+#import "@preview/theorion:0.4.1": *
 #import cosmos.clouds: *
 #show: show-theorion
 


### PR DESCRIPTION
Version 0.4.0 is broken and doesn't compile with Typst 0.14.0. This was fixed in the next version 0.4.1 according to https://github.com/OrangeX4/typst-theorion/releases/tag/0.4.1 and https://github.com/OrangeX4/typst-theorion/commit/b3364f8b33d6d06290bce828bea06133fbeb75c9

Example of the breakage with example from repo:

```
error: unexpected argument
    ┌─ @preview/theorion:0.4.0/core.typ:298:20
    │
298 │   let display-number(get-loc: here) = (counter: frame-counter, ..args) => context {
    │                     ^^^^^^^^^^^^^^^
```

