### PR TITLE
fix: skip special touying labels in short-heading function

### DIFF
--- a/src/utils.typ
+++ b/src/utils.typ
@@ -346,6 +346,15 @@
     return it.body
   }
   let lbl = str(it.label)
+  if lbl in (
+    "touying:hidden",
+    "touying:skip",
+    "touying:unnumbered",
+    "touying:unoutlined",
+    "touying:unbookmarked",
+  ) {
+    return it.body
+  }
   return convert-label-to-short-heading(lbl)
 }
 


### PR DESCRIPTION
Handle special touying labels (touying:hidden, touying:skip, touying:unnumbered, touying:unoutlined, touying:unbookmarked) in the short-heading function by returning the raw body text instead of converting them to short heading format.

Fix for #263