### PR TITLE
IMPORTANT: Fix #309 slide function does not update via scoped import

### DIFF
--- a/src/core.typ
+++ b/src/core.typ
@@ -4765,15 +4765,27 @@
   composer: auto,
   ..bodies,
 ) = touying-slide-wrapper(self => {
-  touying-slide(
-    self: self,
-    config: config,
-    repeat: repeat,
-    setting: setting,
-    composer: composer,
-    ..bodies,
-  )
+  if self.slide-fn != slide {
+    let wrapper = (self.slide-fn)(
+      config: config,
+      repeat: repeat,
+      setting: setting,
+      composer: composer,
+      ..bodies,
+    )
+    (wrapper.value.fn)(self)
+  } else {
+    touying-slide(
+      self: self,
+      config: config,
+      repeat: repeat,
+      setting: setting,
+      composer: composer,
+      ..bodies,
+    )
+  }
 })
+
 
 
 /// Empty slide with no default heading or section context.


### PR DESCRIPTION
See the issue #309 for a detailed problem.

Roughly a scoped theme import does not replace the slide function and thus the default applies.
This is especially bad for simplistic themes as the discrepancy is so small. You might not notice.

The behaviour makes totally sense, but from a user's view this should not be the case.


