### PR TITLE
fix: function `alternatives-match` takes into account parameter `stretch`

### DIFF
--- a/src/core.typ
+++ b/src/core.typ
@@ -1430,7 +1430,7 @@
     },
     subslides-contents,
     position: position,
-    stretch: false,
+    stretch: stretch,
   )
 }
 


### PR DESCRIPTION
Previously, this parameter was ignored, there was no stretching.