### PR TITLE
improved warning via unicode backspace

### DIFF
--- a/src/magic.typ
+++ b/src/magic.typ
@@ -8,9 +8,9 @@
 /// - message (str): The warning message.
 ///
 /// -> content
-#let warning(prefix: "[touying]", message) = {
+#let warning(prefix: "[touying] ", message) = {
   let delete-old-warning = range(21).map(i => "\u{0008}").sum()
-  set text(font: delete-old-warning + prefix + " " + message)
+  set text(font: delete-old-warning + prefix + message)
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
uses unicode backspace to delete the old font warning, and notes that this is a warning from touying.

quick one, but i randomly had the idea and this is much nicer.