### PR TITLE
docs: larify FAQ heading about auto TOC page

### DIFF
--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -556,7 +556,7 @@ Use `#set par(justify: true)`:
 
 ## Headings and Sections
 
-### How do I disable automatic section slides?
+### How do I prevent an highlighted table of contents page from automatically appearing before the top-level title?
 
 Set `config-common(new-section-slide-fn: none)`:
 

--- a/docs/zh/faq.md
+++ b/docs/zh/faq.md
@@ -692,7 +692,7 @@ Text now uses the custom font.
 
 ## 标题与章节
 
-### 如何禁用自动章节幻灯片？
+### 如何阻止一级标题前自动出现带强调的目录页？
 
 设置 `config-common(new-section-slide-fn: none)`：
 


### PR DESCRIPTION
Update the FAQ headings in English and Chinese to more precisely describe the issue: replace the vague "disable automatic section slides" heading with wording that explains preventing a highlighted table-of-contents page from appearing before the top-level title. The example/config remains unchanged (config-common(new-section-slide-fn: none)). Files updated: docs/en/faq.md, docs/zh/faq.md.