### PR TITLE
export the raw touying-fn-wrapper as well

### DIFF
--- a/src/exports.typ
+++ b/src/exports.typ
@@ -25,6 +25,7 @@
   speaker-note,
   touying-equation,
   touying-fn-wrapper,
+  touying-fn-wrapper-raw,
   touying-mitex,
   touying-raw,
   touying-recall,


### PR DESCRIPTION
exports the `touying-fn-wrapper-raw` via exports.typ

thought this should finally be done, so people can use it as well