### PR TITLE
Docs: clarify Tinymist LSP, lazy-layout default, frozen-counters, and theme/color FAQs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you like it, consider [giving a star ⭐ on GitHub](https://github.com/touyin
 
 ## Quick Start
 
-Make sure you have [Typst](https://typst.app/) installed, or use the [Web App](https://typst.app/) / [Tinymist for VS Code](https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist).
+Make sure you have [Typst](https://typst.app/) installed, or use the [Web App](https://typst.app/) / [Tinymist LSP](https://github.com/Myriad-Dreamin/tinymist) in an editor with LSP support (including the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist)).
 
 ```typst
 #import "@preview/touying:0.7.4": *

--- a/docs/en/external/typst-preview.md
+++ b/docs/en/external/typst-preview.md
@@ -4,11 +4,11 @@ sidebar_position: 5
 
 # Typst Preview in Tinymist
 
-The Tinymist extension for VS Code provides an excellent slide mode, allowing us to preview and present slides.
+Tinymist provides an excellent slide mode, allowing us to preview and present slides from editors that support its preview commands. In VS Code, these commands are available from the command palette.
 
-Press `Ctrl/Cmd + Shift + P` and type `Typst Preview: Preview current file in slide mode` to open the preview in slide mode.
+In VS Code, press `Ctrl/Cmd + Shift + P` and type `Typst Preview: Preview current file in slide mode` to open the preview in slide mode.
 
-Press `Ctrl/Cmd + Shift + P` and type `Typst Preview: Preview current file in browser and slide mode` to open the slide mode in the browser.
+In VS Code, press `Ctrl/Cmd + Shift + P` and type `Typst Preview: Preview current file in browser and slide mode` to open the slide mode in the browser.
 
 Now, you can press keys like `F11` to enter fullscreen mode in the browser, making it suitable for slide presentations.
 

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -44,6 +44,34 @@ Pass a `config-colors(...)` argument to your theme:
 The header now uses the custom primary color.
 ```
 
+
+### How do I access the current theme colors in slide content?
+
+Theme colors live on `self.colors`. In ordinary slide content, wrap a function with `touying-fn-wrapper` so Touying can pass the current slide context as `self`:
+
+```example
+#import "@preview/touying:0.7.4": *
+#import themes.simple: *
+
+#show: simple-theme.with(aspect-ratio: "16-9")
+
+= Section
+
+== Slide
+
+#touying-fn-wrapper((self: none) => text(fill: self.colors.primary)[
+  This text uses the current theme's primary color.
+])
+
+#touying-fn-wrapper((self: none) => rect(
+  fill: self.colors.secondary,
+  width: 4em,
+  height: 1em,
+))
+```
+
+If you are writing a theme method or callback that already receives `self`, access colors directly as `self.colors.primary`, `self.colors.neutral-lightest`, and so on.
+
 ---
 
 ## Layout and Columns
@@ -135,6 +163,33 @@ More content here.
 ```
 
 The `<touying:hidden>` label hides the outline slide from the outline itself.
+
+
+### How do I keep only the main outline and disable automatic section slides?
+
+Some themes generate an automatic section slide (often an outline or section overview) when they see a new top-level section (`=`). Disable those generated section slides with `config-common(new-section-slide-fn: none)`, then keep only the main outline slide you write yourself:
+
+```example
+#import "@preview/touying:0.7.4": *
+#import themes.metropolis: *
+
+#show: metropolis-theme.with(
+  aspect-ratio: "16-9",
+  config-common(new-section-slide-fn: none),
+)
+
+== Outline <touying:hidden>
+
+#components.adaptive-columns(outline(title: none, indent: 1em))
+
+= First Section
+
+== First Slide
+
+= Second Section
+
+== Second Slide
+```
 
 ### How do I add numbering to sections in the outline?
 

--- a/docs/en/integration/theorion.md
+++ b/docs/en/integration/theorion.md
@@ -80,7 +80,7 @@ Touying renders each subslide by re-evaluating slide content. Without `frozen-co
 If you also have figure counters that should be frozen:
 
 ```typst
-config-common(frozen-counters: (theorem-counter, figure.where(kind: image)))
+config-common(frozen-counters: (theorem-counter, counter(figure.where(kind: image))))
 ```
 
 ## Cosmos Styles

--- a/docs/en/intro.md
+++ b/docs/en/intro.md
@@ -24,7 +24,7 @@ You have two main options:
 | Option | Description |
 |--------|-------------|
 | **[Typst Web App](https://typst.app/)** | Browser-based editor. No installation needed; just open `typst.app`, create a new project, and start writing. Supports real-time preview and collaboration. |
-| **[Tinymist for VS Code](https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist)** | A full-featured Typst LSP extension for VS Code. Provides syntax highlighting, autocomplete, error diagnostics, and a built-in slide preview panel. |
+| **[Tinymist LSP](https://github.com/Myriad-Dreamin/tinymist)** | A full-featured Typst language server that works with editors supporting LSP. Provides syntax highlighting, autocomplete, error diagnostics, and slide preview; a VS Code extension is also available. |
 
 Both options automatically download Touying from the Typst package registry — no separate installation step is required.
 

--- a/docs/en/start.md
+++ b/docs/en/start.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Getting Started
 
-Before you begin, make sure you have the Typst environment installed. If not, you can use the [Web App](https://typst.app/) or install the [Tinymist LSP](https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist) plugins for VS Code.
+Before you begin, make sure you have the Typst environment installed. If not, you can use the [Web App](https://typst.app/) or install [Tinymist LSP](https://github.com/Myriad-Dreamin/tinymist) in any editor with LSP support; Tinymist also provides a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist).
 
 To use Touying, you just need to include the following in your document:
 

--- a/docs/en/tutorials/layout.md
+++ b/docs/en/tutorials/layout.md
@@ -152,13 +152,13 @@ When using multi-column layouts (via `cols` or a manual `grid`), columns with di
 
 ### Using `cols` (Recommended)
 
-`cols` enables `lazy-layout` by default, so you just need to add `lazy-v(1fr)` inside each block:
+`cols` does not enable `lazy-layout` by default. Pass `lazy-layout: true` to `cols`, then add `lazy-v(1fr)` inside each block:
 
 ```example
 >>> #import "@preview/touying:0.7.4": *
 >>> #import themes.simple: *
 >>> #show: simple-theme
-#cols[
+#cols(lazy-layout: true)[
   #block(fill: luma(220), inset: .5em, radius: .2em, width: 100%)[
     #lorem(10)
     #lazy-v(1fr)
@@ -206,7 +206,7 @@ You can also wrap a `grid` with `lazy-layout` directly:
 
 :::tip[Tip]
 
-If you don't need the height-equalizing behavior, pass `lazy-layout: false` to `cols` to opt out.
+`cols` defaults to `lazy-layout: false`. Enable it only when you need height equalization.
 
 :::
 

--- a/docs/en/tutorials/settings.md
+++ b/docs/en/tutorials/settings.md
@@ -151,10 +151,10 @@ Now we have codly available.
 When using animation, figure and theorem counters inside a single slide keep advancing per subslide by default. To freeze a counter (so it does not change between subslides), use:
 
 ```typst
-config-common(frozen-counters: (figure.where(kind: image),))
+config-common(frozen-counters: (counter(figure.where(kind: image)),))
 ```
 
-This is especially useful when working with the [Theorion](../integration/theorion.md) package:
+For custom figure kinds, pass `counter(figure.where(kind: "Name"))` rather than the selector itself; `frozen-counters` expects counters. This is also useful when working with the [Theorion](../integration/theorion.md) package:
 
 ```typst
 config-common(frozen-counters: (theorem-counter,))

--- a/docs/zh/external/typst-preview.md
+++ b/docs/zh/external/typst-preview.md
@@ -4,11 +4,11 @@ sidebar_position: 5
 
 # Typst Preview in Tinymist
 
-VS Code 的 Tinymist 插件提供了优秀的 slide mode，我们可以用其预览和放映 slides。
+Tinymist 提供了优秀的 slide mode，我们可以在支持其预览命令的编辑器中预览和放映 slides。在 VS Code 中，这些命令可以从命令面板调用。
 
-按下 `Ctrl/Cmd + Shift + P`，并输入 `Typst Preview: Preview current file in slide mode`，就可以打开 slide mode 的预览。
+在 VS Code 中，按下 `Ctrl/Cmd + Shift + P`，并输入 `Typst Preview: Preview current file in slide mode`，就可以打开 slide mode 的预览。
 
-按下 `Ctrl/Cmd + Shift + P`，并输入 `Typst Preview: Preview current file in browser and slide mode`，就可以在浏览器打开 slide mode。
+在 VS Code 中，按下 `Ctrl/Cmd + Shift + P`，并输入 `Typst Preview: Preview current file in browser and slide mode`，就可以在浏览器打开 slide mode。
 
 这时候你可以按下 `F11` 之类的键，进入浏览器的全屏模式，就可以用于 slides 放映了。
 

--- a/docs/zh/faq.md
+++ b/docs/zh/faq.md
@@ -44,6 +44,33 @@ Using the simple theme.
 The header now uses the custom primary color.
 ```
 
+
+### 如何在正文中访问当前主题颜色？
+
+主题颜色保存在 `self.colors` 中。在普通幻灯片正文里，可以用 `touying-fn-wrapper` 包裹一个函数，让 Touying 把当前幻灯片上下文作为 `self` 传入：
+
+```example
+#import "@preview/touying:0.7.4": *
+#import themes.simple: *
+#show: simple-theme.with(aspect-ratio: "16-9")
+
+= Section
+
+== Slide
+
+#touying-fn-wrapper((self: none) => text(fill: self.colors.primary)[
+  This text uses the current theme's primary color.
+])
+
+#touying-fn-wrapper((self: none) => rect(
+  fill: self.colors.secondary,
+  width: 4em,
+  height: 1em,
+))
+```
+
+如果你正在编写已经接收 `self` 的主题方法或回调函数，则可以直接使用 `self.colors.primary`、`self.colors.neutral-lightest` 等颜色。
+
 ---
 
 ## config-common 配置参考
@@ -290,6 +317,32 @@ More content here.
 ```
 
 `<touying:hidden>` 标签可将目录幻灯片本身从目录中隐藏。
+
+
+### 如何只保留主目录并禁用自动章节页？
+
+有些主题在遇到新的一级章节（`=`）时，会自动生成章节页（通常是目录或章节概览）。可以用 `config-common(new-section-slide-fn: none)` 关闭这些自动章节页，然后只保留你手动编写的主目录页：
+
+```example
+#import "@preview/touying:0.7.4": *
+#import themes.metropolis: *
+#show: metropolis-theme.with(
+  aspect-ratio: "16-9",
+  config-common(new-section-slide-fn: none),
+)
+
+== Outline <touying:hidden>
+
+#components.adaptive-columns(outline(title: none, indent: 1em))
+
+= First Section
+
+== First Slide
+
+= Second Section
+
+== Second Slide
+```
 
 ### 如何为目录中的章节添加编号？
 

--- a/docs/zh/integration/theorion.md
+++ b/docs/zh/integration/theorion.md
@@ -81,7 +81,7 @@ Touying 通过重新求值幻灯片内容来渲染每个子幻灯片。若不使
 如果你还有需要冻结的图表计数器，可以这样配置：
 
 ```typst
-config-common(frozen-counters: (theorem-counter, figure.where(kind: image)))
+config-common(frozen-counters: (theorem-counter, counter(figure.where(kind: image))))
 ```
 
 ## Cosmos 样式

--- a/docs/zh/intro.md
+++ b/docs/zh/intro.md
@@ -24,7 +24,7 @@ sidebar_position: 1
 | 选项 | 说明 |
 |------|------|
 | **[Typst Web App](https://typst.app/)** | 基于浏览器的编辑器，无需安装；打开 `typst.app`，创建新项目即可开始编写。支持实时预览和协作。 |
-| **[Tinymist for VS Code](https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist)** | 功能完整的 Typst LSP 扩展。提供语法高亮、自动补全、错误诊断以及内置幻灯片预览面板。 |
+| **[Tinymist LSP](https://github.com/Myriad-Dreamin/tinymist)** | 功能完整的 Typst 语言服务器，可用于支持 LSP 的编辑器。提供语法高亮、自动补全、错误诊断和幻灯片预览；同时也提供 VS Code 扩展。 |
 
 两种方式均会自动从 Typst 包注册表下载 Touying，无需单独安装。
 

--- a/docs/zh/start.md
+++ b/docs/zh/start.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # 开始
 
-在开始之前，请确保您已经安装了 Typst 环境，如果没有，可以使用 [Web App](https://typst.app/) 或 VS Code 的 [Tinymist LSP](https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist) 插件。
+在开始之前，请确保您已经安装了 Typst 环境。如果没有，可以使用 [Web App](https://typst.app/)，或在任何支持 LSP 的编辑器中安装 [Tinymist LSP](https://github.com/Myriad-Dreamin/tinymist)；Tinymist 也提供 [VS Code 扩展](https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist)。
 
 要使用 Touying，您只需要在文档里加入
 

--- a/docs/zh/tutorials/layout.md
+++ b/docs/zh/tutorials/layout.md
@@ -153,13 +153,13 @@ config-page(footer: [Custom Footer])
 
 ### 使用 `cols`（推荐）
 
-`cols` 默认启用 `lazy-layout`，你只需要在每个 block 内添加 `lazy-v(1fr)` 即可：
+`cols` 默认不会启用 `lazy-layout`。需要给 `cols` 传入 `lazy-layout: true`，然后在每个 block 内添加 `lazy-v(1fr)`：
 
 ```example
 >>> #import "@preview/touying:0.7.4": *
 >>> #import themes.simple: *
 >>> #show: simple-theme
-#cols[
+#cols(lazy-layout: true)[
   #block(fill: luma(220), inset: .5em, radius: .2em, width: 100%)[
     #lorem(10)
     #lazy-v(1fr)
@@ -208,7 +208,7 @@ config-page(footer: [Custom Footer])
 
 :::tip[提示]
 
-如果不需要高度对齐的行为，可以给 `cols` 传入 `lazy-layout: false` 来关闭。
+`cols` 的默认值是 `lazy-layout: false`。只有需要高度对齐行为时才启用它。
 
 :::
 

--- a/docs/zh/tutorials/settings.md
+++ b/docs/zh/tutorials/settings.md
@@ -147,10 +147,10 @@ Now we have codly available.
 
 在使用动画时，单张幻灯片内的图表和定理计数器默认会随每个子幻灯片递增。若要冻结某个计数器（使其在子幻灯片之间保持不变），请使用：
 ```typst
-config-common(frozen-counters: (figure.where(kind: image),))
+config-common(frozen-counters: (counter(figure.where(kind: image)),))
 ```
 
-在使用 [Theorion](../integration/theorion.md) 包时这尤为有用：
+对于自定义 figure kind，请传入 `counter(figure.where(kind: "Name"))`，而不是 selector 本身；`frozen-counters` 需要的是 counter。在使用 [Theorion](../integration/theorion.md) 包时这也尤为有用：
 ```typst
 config-common(frozen-counters: (theorem-counter,))
 ```


### PR DESCRIPTION
### Motivation

- Improve and correct user-facing documentation about editor integration, layout behavior, counter freezing, and theme APIs so examples are accurate and applicable to more editors. 

### Description

- Update `README.md` and several docs to refer to `Tinymist LSP` (linking to the repo) instead of implying a VS Code-only integration and clarify that a VS Code extension is available. 
- Clarify Typst Preview instructions by explaining that Tinymist preview commands are available from the command palette in VS Code and that the preview is usable from other editors supporting the preview commands. 
- Add FAQ entries showing how to access theme colors via `self.colors` and how to use `touying-fn-wrapper` to pass `self` into slide content. 
- Add guidance to disable automatic generated section slides with `config-common(new-section-slide-fn: none)` and show an example. 
- Correct `frozen-counters` examples so it expects counters by wrapping selectors with `counter(...)` (e.g. `counter(figure.where(kind: image))`). 
- Correct `cols`/`lazy-layout` documentation to state that `cols` defaults to `lazy-layout: false` and show how to enable it via `#cols(lazy-layout: true)[...]` instead of claiming it is enabled by default. 
- Apply corresponding changes to both English and Chinese documentation files under `docs/`.

### Testing

- No unit tests were modified for this change; this PR only updates documentation. 
- Documentation sanity-checked by inspecting the edited pages and examples for correctness (local static docs review completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2540649b3c832c8adb2792fe3aa277)