### PR TITLE
Theme fix: Fix footer height for multi-line titles for `University` theme

### DIFF
--- a/themes/university.typ
+++ b/themes/university.typ
@@ -77,7 +77,7 @@
       show: block.with(width: 100%, height: auto)
       grid(
         columns: self.store.footer-columns,
-        rows: 1.5em,
+        rows: auto,
         cell(fill: self.colors.primary, utils.call-or-display(
           self,
           self.store.footer-a,


### PR DESCRIPTION
# Motivation: 
If one has a multi-line title, it clips in the footer. This pull request is proposed to fix the problem.

# Description: 
Add dynamic adjustment to footer height from `1.5em` to `auto` to accommodate for multi-line title. 

# Testing: 
No proposed testing. Since typst layout system should work fine for `auto`.