### PR TITLE
Guard against empty output when adding last-page metadata and add regression test

### DIFF
--- a/src/core.typ
+++ b/src/core.typ
@@ -1100,8 +1100,10 @@
     if slide-content != none { output-slides.push(slide-content) }
   }
 
-  //add last page metadata to last physical page.
-  if is-outer-call {
+  // Add last-page metadata to the last physical page when one exists.
+  // Empty documents can legitimately produce no slides, so avoid indexing the
+  // empty output list.
+  if is-outer-call and output-slides.len() > 0 {
     output-slides.at(-1) += [#metadata(none)#label("touying-last-page")]
   }
 

--- a/tests/issues/i379-empty-document/test.typ
+++ b/tests/issues/i379-empty-document/test.typ
@@ -1,0 +1,13 @@
+// This is intentionally a compile-only tytanic test without `ref/*.png`.
+// The regression is an empty-document compilation crash, so a successful
+// compile is the assertion and no visual output is expected.
+
+#import "/lib.typ": *
+#import themes.simple: *
+
+#show: simple-theme.with(
+  aspect-ratio: "16-9",
+  config-info(
+    title: [A title],
+  ),
+)


### PR DESCRIPTION
### Motivation

- Prevent a crash when compiling documents that produce no slides by avoiding indexing into an empty `output-slides` list.  
- Add a compile-only regression test to ensure empty-document compilation remains successful.  

### Description

- Change the last-page metadata logic in `src/core.typ` to only add metadata when `is-outer-call` and `output-slides.len() > 0`.  
- Improve the inline comment to document that empty documents may produce no slides and should not be indexed.  
- Add a compile-only regression test at `tests/issues/i379-empty-document/test.typ` that verifies an empty document compiles without producing visual output.  

### Testing

- Ran the automated test suite including the new regression test `tests/issues/i379-empty-document/test.typ`, and the suite passed.  
- The new compile-only tytanic test successfully compiles and prevents the previously observed crash.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a292e5dad7c832c8b50b34a44de3663)