### PR TITLE
Preserve grid/table cell metadata when covering and let absolute jumps escape outer hiding

### DIFF
--- a/src/core.typ
+++ b/src/core.typ
@@ -4265,9 +4265,11 @@
   // last-subslide by touying-fn-wrapper — inherit outer context so waypoints
   // placed after multi-subslide fn-wrappers fire correctly inside sub-sequences.
   let last-subslide = base-last-subslide
-  // Whether any touying-fn-wrapper was found in this parse (directly or via
-  // recursive calls).  Used by the two-pass escape hatch so that fn-wrappers
-  // inside a pause zone can handle their own visibility.
+  // Whether this parse contains content that can become visible before the
+  // surrounding repetition counter would normally reveal the whole container
+  // (fn-wrappers with their own visibility, or absolute jumps/meanwhile).
+  // Used by the two-pass escape hatch so such content can handle its own
+  // visibility inside a pause zone.
   let has-fn-wrapper = false
   // get cover function from self
   let cover = self.methods.cover.with(self: self)
@@ -4289,7 +4291,9 @@
           if it.body.value.relative {
             repetitions = calc.max(repetitions, last-subslide) + it.body.value.n
           } else {
-            // absolute jump
+            // absolute jump: the cell body can become visible earlier than
+            // the surrounding container, so it must escape outer hiding.
+            has-fn-wrapper = true
             max-repetitions = calc.max(max-repetitions, repetitions)
             repetitions = it.body.value.n
             last-subslide = 0
@@ -4393,7 +4397,31 @@
           false
         }
       }
-      let covered = cover-fn(items.sum())
+      let cover-item = item => {
+        // Preserve table/grid cell metadata (e.g. rowspan/colspan) while
+        // covering only the cell body. Covering the whole cell turns it into a
+        // generic hidden content node, so grid/table layout loses the cell
+        // placement information.
+        if type(item) == content and item.func() in (table.cell, grid.cell) {
+          let body = item.at("body", default: none)
+          if body != none {
+            return utils.reconstruct(
+              named: true,
+              labeled: labeled(item.func()),
+              item,
+              cover-fn(body),
+            )
+          }
+        }
+        cover-fn(item)
+      }
+      let covered = if items.all(item => (
+        type(item) == content and item.func() in (table.cell, grid.cell)
+      )) {
+        items.map(cover-item).sum(default: none)
+      } else {
+        cover-fn(items.sum())
+      }
       //decrease below spacing for rect cover functions
       // if type(cover-fn) == function and (
       //   cover-fn==utils.cover-with-rect or
@@ -4462,7 +4490,10 @@
               hidden-parts = ()
             }
           } else {
-            // absolute: reveal all hidden content then jump to target subslide
+            // absolute: reveal all hidden content then jump to target subslide.
+            // This can make later content visible before the surrounding
+            // container's original repetition, so it must escape outer hiding.
+            has-fn-wrapper = true
             if hidden-parts.len() != 0 {
               result.push(cover-hidden(cover, hidden-parts, result))
               hidden-parts = ()

--- a/tests/issues/i369-i373-grid-regressions/test.typ
+++ b/tests/issues/i369-i373-grid-regressions/test.typ
@@ -1,0 +1,51 @@
+// Minimal regressions for grid/cell animation issues.
+// - #369: covering a paused grid.cell must preserve rowspan/colspan metadata.
+// - #373: #meanwhile inside a container must escape outer hiding.
+
+#import "/lib.typ": *
+#import themes.simple: *
+
+#show: simple-theme.with(aspect-ratio: "16-9")
+
+#let tile(fill, body) = rect(
+  fill: fill,
+  width: 100%,
+  height: 2.5em,
+  inset: .4em,
+  body,
+)
+
+== Preserve grid.cell while covered
+
+#grid(
+  columns: (1fr, 1fr),
+  gutter: .5em,
+  tile(aqua.lighten(50%), [top-left]),
+  pause,
+  grid.cell(rowspan: 2, tile(red.lighten(60%), [rowspan-right])),
+  tile(blue.lighten(70%), [bottom-left]),
+)
+
+== Meanwhile with reducer inside grid
+
+#let mini-reducer(..args) = touying-reducer(
+  reduce: arr => arr.sum(default: none),
+  cover: arr => hide(arr.sum(default: none)),
+  ..args,
+)
+
+#grid(
+  columns: (1fr, 1fr),
+  gutter: .5em,
+  mini-reducer(
+    [left-1],
+    pause,
+    [left-2],
+  ),
+  [
+    #meanwhile
+    right-1
+    #pause
+    right-2
+  ],
+)


### PR DESCRIPTION
### Motivation
- Preserve `rowspan`/`colspan` and other cell metadata when covering paused `table.cell`/`grid.cell` so layout is not lost.  
- Ensure content that can become visible earlier than its container (fn-wrappers or absolute jumps/`#meanwhile`) can escape outer hiding and manage its own visibility inside pause zones.  

### Description
- Treat absolute jumps inside cell metadata and child metadata as escapes by setting `has-fn-wrapper = true` when an absolute jump is encountered.  
- Introduce `cover-item` to apply `cover-fn` only to a cell's body and reconstruct the original `table.cell`/`grid.cell` node so cell metadata is preserved.  
- Change covered computation to map `cover-item` over items when all items are cells, and otherwise call `cover-fn(items.sum())`.  
- Add a regression test file `tests/issues/i369-i373-grid-regressions/test.typ` covering the grid/cell covering and `#meanwhile` escape cases.  

### Testing
- Added and ran the regression test `tests/issues/i369-i373-grid-regressions/test.typ`, and it passed.
