### PR TITLE
Fix cetz docs and diagram broken

### DIFF
--- a/docs/en/integration/cetz.md
+++ b/docs/en/integration/cetz.md
@@ -70,7 +70,7 @@ An example:
 
 ## only and uncover
 
-In fact, we can also use `only` and `uncover` within CeTZ, but it requires a bit of technique:
+Similarly we can also use `only` and `uncover`. Notice that for Cetz you need to wrap touying's smart animation commands in an array `(only(...),)` whereas in Fletcher you can write them natively.
 
 ```example
 #import "@preview/touying:0.7.4": *
@@ -78,8 +78,8 @@ In fact, we can also use `only` and `uncover` within CeTZ, but it requires a bit
 #import themes.simple: *
 #show: simple-theme.with(aspect-ratio: "16-9")
 
-// cetz and fletcher bindings for touying
-#let cetz-canvas = touying-reduce.with(cetz) // new syntax for packages that expose their name
+// cetz bindings for touying
+#let cetz-canvas = touying-diagram.with(cetz) // new syntax for packages that expose their name
 
 == Only and Uncover in Cetz
 
@@ -90,20 +90,21 @@ Cetz in Touying in subslide #touying-get-config("subslide")
   
   rect((0,0), (5,5))
 
-  uncover("2-3", {
+  (uncover("2-3", {
     rect((0,0), (1,1))
     rect((1,1), (2,2))
     rect((2,2), (3,3))
-  })
+  }),)
 
-  only(3, line((0,0), (2.5, 2.5), name: "line"))
+  (only(3, line((0,0), (2.5, 2.5), name: "line")),)
 })
 
 ```
 
 ## only and uncover with slide self
 
-We can also pass the slide self and then use the utils methods. Note: you must count your subslides for this and parse in the correct `repeat`.
+We can also pass the slide self and then use the utils methods. You don't need to wrap these in an array. Note: you must count your subslides for this and parse in the correct `repeat` count.
+
 
 ```example
 #import "@preview/touying:0.7.4": *
@@ -118,17 +119,17 @@ We can also pass the slide self and then use the utils methods. Note: you must c
 
   #cetz.canvas({
     import cetz.draw: *
-    let uncover = uncover.with(cover-fn: hide.with(bounds: true))
+    let uncover = uncover.with(cover-fn: hide.with(bounds: true)) //use cetz' hide function for covering
     
     rect((0,0), (5,5))
 
-    uncover("2-3", {
+    (uncover("2-3", {
       rect((0,0), (1,1))
       rect((1,1), (2,2))
       rect((2,2), (3,3))
-    })
+    }),)
 
-    only(3, line((0,0), (2.5, 2.5), name: "line"))
+    (only(3, line((0,0), (2.5, 2.5), name: "line")),)
   })
 ])
 ```

--- a/docs/en/integration/fletcher.md
+++ b/docs/en/integration/fletcher.md
@@ -70,7 +70,7 @@ An example with callback-style:
 #import "@preview/fletcher:0.5.8" as fletcher: diagram, edge, node
 #show: themes.simple.simple-theme.with(aspect-ratio: "16-9")
 
-#let diagram = touying-reducer.with(reduce: fletcher.diagram, cover: fletcher.hide)
+#let diagram = touying-diagram.with(fletcher)
 
 #slide(repeat: 6, self => {
   let (uncover, only, alternatives) = utils.methods(self)

--- a/docs/zh/integration/cetz.md
+++ b/docs/zh/integration/cetz.md
@@ -70,7 +70,7 @@ Touying 提供了 `touying-diagram`/`touying-reduce` 函数（同义），它们
 
 ## only 与 uncover
 
-事实上，我们也可以在 cetz 内部使用 `only` 和 `uncover`，只是需要一点技巧：
+同样，我们也可以使用 `only` 和 `uncover`。注意：在 Cetz 中，你需要将 Touying 的智能动画命令包裹在数组中，如 `(only(...),)`，而在 Fletcher 中则可以直接原生书写。
 
 ```example
 #import "@preview/touying:0.7.4": *
@@ -78,8 +78,8 @@ Touying 提供了 `touying-diagram`/`touying-reduce` 函数（同义），它们
 #import themes.simple: *
 #show: simple-theme.with(aspect-ratio: "16-9")
 
-// cetz and fletcher bindings for touying
-#let cetz-canvas = touying-reduce.with(cetz) // 对于暴露了包名的包可使用的新语法
+// cetz bindings for touying
+#let cetz-canvas = touying-diagram.with(cetz) // 对于暴露了包名的包可使用的新语法
 
 == Cetz 中的 Only 与 Uncover
 
@@ -90,20 +90,20 @@ Cetz in Touying in subslide #touying-get-config("subslide")
   
   rect((0,0), (5,5))
 
-  uncover("2-3", {
+  (uncover("2-3", {
     rect((0,0), (1,1))
     rect((1,1), (2,2))
     rect((2,2), (3,3))
-  })
+  }),)
 
-  only(3, line((0,0), (2.5, 2.5), name: "line"))
+  (only(3, line((0,0), (2.5, 2.5), name: "line")),)
 })
 
 ```
 
 ## 使用 slide self 的 only 与 uncover
 
-我们也可以传入 slide 的 self，然后使用 utils 方法。注意：你必须为此正确计算子幻灯片数量，并传入正确的 `repeat`。
+我们也可以传入 slide 的 self，然后使用 utils 方法。无需将这些包裹在数组中。注意：你必须为此正确计算子幻灯片数量，并传入正确的 `repeat` 数量。
 
 ```example
 #import "@preview/touying:0.7.4": *
@@ -118,17 +118,17 @@ Cetz in Touying in subslide #touying-get-config("subslide")
 
   #cetz.canvas({
     import cetz.draw: *
-    let uncover = uncover.with(cover-fn: hide.with(bounds: true))
+    let uncover = uncover.with(cover-fn: hide.with(bounds: true)) //使用 cetz 的 hide 函数进行遮盖
     
     rect((0,0), (5,5))
 
-    uncover("2-3", {
+    (uncover("2-3", {
       rect((0,0), (1,1))
       rect((1,1), (2,2))
       rect((2,2), (3,3))
-    })
+    }),)
 
-    only(3, line((0,0), (2.5, 2.5), name: "line"))
+    (only(3, line((0,0), (2.5, 2.5), name: "line")),)
   })
 ])
 ```

--- a/docs/zh/integration/fletcher.md
+++ b/docs/zh/integration/fletcher.md
@@ -70,7 +70,7 @@ Touying 提供了 `touying-diagram`/`touying-reduce` 函数（同义），它们
 #import "@preview/fletcher:0.5.8" as fletcher: diagram, edge, node
 #show: themes.simple.simple-theme.with(aspect-ratio: "16-9")
 
-#let diagram = touying-reducer.with(reduce: fletcher.diagram, cover: fletcher.hide)
+#let diagram = touying-diagram.with(fletcher)
 
 #slide(repeat: 6, self => {
   let (uncover, only, alternatives) = utils.methods(self)

--- a/src/core.typ
+++ b/src/core.typ
@@ -2842,7 +2842,7 @@
   package,
   bindings: (reduce: none, cover: none),
   ..args,
-) = touying-reduce(package, bindings, ..args)
+) = touying-reduce(package, bindings:bindings, ..args)
 
 /// Parse touying equation content and extract animation repetitions
 ///


### PR DESCRIPTION
mini fixes:

- doc for smart animation commands within cetz diagram was wrong: need to wrap the cmds in arrays

- explain the difference a bit better

- fix touying-diagram not working bc binding needs to be named arg