### PR TITLE
fix github issue 391 for Typst 0.15.0

### DIFF
--- a/src/components.typ
+++ b/src/components.typ
@@ -1006,16 +1006,13 @@
 /// -> content
 #let knob-marker(primary: rgb("#005bac")) = box(
   width: 0.5em,
-  place(
-    dy: 0.1em,
-    circle(
-      fill: gradient.radial(
-        primary.lighten(100%),
-        primary.darken(40%),
-        focal-center: (30%, 30%),
-      ),
-      radius: 0.25em,
+  circle(
+    fill: gradient.radial(
+      primary.lighten(100%),
+      primary.darken(40%),
+      focal-center: (30%, 30%),
     ),
+    radius: 0.25em,
   ),
 )
 


### PR DESCRIPTION
This pull request fixes #391 for Typst version 0.15.0.

It is \***NOT COMPATIBLE**\* with previous Typst versions (i.e. <= 0.14.2) since mitigation 2 is not applied.