### PR TITLE
Add a function left-mid-right to place content on three columns

### DIFF
--- a/src/components.typ
+++ b/src/components.typ
@@ -359,6 +359,20 @@
   left, none, right,
 )
 
+/// Place three content blocks at the left, in the middle and right edges of the available width using a five-column grid.
+///
+/// - left (content): The content of the left part.
+///
+/// - mid (content): The content of the middle part.
+///
+/// - right (content): The content of the right part.
+///
+/// -> content
+#let left-mid-right(left, mid, right) = grid(
+  columns: (auto, 1fr, auto, 1fr, auto),
+  left, none, mid, none, right,
+)
+
 
 /// Create a slide where the provided content blocks are displayed in a grid with a checkerboard color pattern.
 ///

--- a/src/components.typ
+++ b/src/components.typ
@@ -368,9 +368,9 @@
 /// - right (content): The content of the right part.
 ///
 /// -> content
-#let left-mid-right(left, mid, right) = grid(
-  columns: (auto, 1fr, auto, 1fr, auto),
-  left, none, mid, none, right,
+#let left-mid-right(l, m, r) = grid(
+  columns: (1fr, auto, 1fr),
+  l, m, align(right, r),
 )
 
 


### PR DESCRIPTION
For a theme I'm developing, I needed to create a function that split in three the content of the footer (Author, Title, and page number).

If this function can be needed in the package in the future, I gladly share it :)

*NB :* I think there is way to improvement, for instance the title may not be centered...

Thanks for the package !