### PR TITLE
fix wrong type in pdfpc commands

### DIFF
--- a/src/pdfpc.typ
+++ b/src/pdfpc.typ
@@ -35,11 +35,11 @@
         page.hidden = true
       } else if item.t == "SaveSlide" {
         if "savedSlide" not in pdfpc {
-          pdfpc.savedSlide = page.label - 1
+          pdfpc.savedSlide = int(page.label) - 1
         }
       } else if item.t == "EndSlide" {
         if "endSlide" not in pdfpc {
-          pdfpc.endSlide = page.label - 1
+          pdfpc.endSlide = int(page.label) - 1
         }
       } else if item.t == "Note" {
         page.note = if "note" in page {


### PR DESCRIPTION
Cast the page label from string to integer for subtraction in pdfpc end-slide and save-slide handling.

Fixes #404 