### PR TITLE
docs: replace deprecated `typst query` with `typst eval`

### DIFF
--- a/docs/en/external/pdfpc.md
+++ b/docs/en/external/pdfpc.md
@@ -46,7 +46,7 @@ Add the corresponding configurations. Refer to [Polylux](https://polylux.dev/boo
 Assuming your document is `./example.typ`, you can export the `.pdfpc` file directly using:
 
 ```sh
-typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc
+typst eval --in ./example.typ 'query(<pdfpc-file>).first().value' > ./example.pdfpc
 ```
 
 With the compatibility of Touying and Polylux, you can make Polylux also support direct export by adding the following code:

--- a/docs/zh/external/pdfpc.md
+++ b/docs/zh/external/pdfpc.md
@@ -46,7 +46,7 @@ Touying 与 [Polylux](https://polylux.dev/book/external/pdfpc.html) 保持一致
 假设你的文档为 `./example.typ`，则你可以通过
 
 ```sh
-typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc
+typst eval --in ./example.typ 'query(<pdfpc-file>).first().value' > ./example.pdfpc
 ```
 
 直接导出 `.pdfpc` 文件。

--- a/src/pdfpc.typ
+++ b/src/pdfpc.typ
@@ -1,7 +1,7 @@
 // Attribution: This file is based on the code from https://github.com/andreasKroepelin/polylux/blob/main/utils/pdfpc.typ
 // Author: Andreas Kröpelin
 
-/// Generate pdfpc metadata for the presentation. Called internally in the preamble when `enable-pdfpc` is `true`. Query the result with `typst query --root . ./example.typ --field value --one "<pdfpc-file>" > ./example.pdfpc`.
+/// Generate pdfpc metadata for the presentation. Called internally in the preamble when `enable-pdfpc` is `true`. Query the result with `typst eval --in ./example.typ 'query(<pdfpc-file>).first().value' > ./example.pdfpc`.
 ///
 /// -> content
 #let pdfpc-file(loc) = {


### PR DESCRIPTION
When using the mentioned command with typst version 0.15 and above, the following warning will be emitted:

warning: the `typst query` subcommand is deprecated
 = hint: use `typst eval 'query(<pdfpc-file>).first().value' --in ./example.typ` instead