### PR TITLE
Fix broken star history chart by switching to star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,10 +381,10 @@ Thanks to...
 
 ## Star History
 
-<a href="https://star-history.com/#touying-typ/touying&Date">
+<a href="https://star-history.dera.page/#touying-typ/touying&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=touying-typ/touying&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=touying-typ/touying&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=touying-typ/touying&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=touying-typ/touying&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=touying-typ/touying&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=touying-typ/touying&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points it to the star-history.dera.page mirror, which serves both the frontend and the /svg chart from a single domain using an alternative data source that requires no API token.