### PR TITLE
Theme fix: Don't show linebreak in footer with university and stargazer theme.

### DIFF
--- a/themes/stargazer.typ
+++ b/themes/stargazer.typ
@@ -430,6 +430,7 @@
   let footer(self) = {
     set text(size: .5em)
     set std.align(center + bottom)
+    show linebreak: none
     grid(
       rows: (auto, auto),
       utils.call-or-display(self, self.store.footer),

--- a/themes/university.typ
+++ b/themes/university.typ
@@ -68,6 +68,7 @@
   let footer(self) = {
     set std.align(center + bottom)
     set text(size: .4em)
+    show linebreak: none
     {
       let cell(..args, it) = components.cell(
         ..args,


### PR DESCRIPTION
This pull-request aims at improving the university-theme and the stargazer-theme. In these two themes, the title of the presentation is being displayed in the footer. In case you want a specific linebreak in the title-slide, at the moment, this produces weird behaviour in the footer, see screenshot below:
<img width="678" height="376" alt="university_before" src="https://github.com/user-attachments/assets/7f8ebd6a-f78d-48a5-9acf-133ddc5da495" />
With small change in this pull-request this is fixed:
<img width="650" height="367" alt="image" src="https://github.com/user-attachments/assets/77b24bfb-54ee-48bb-b72f-86c286644ea1" />

