### PR TITLE
Fix bibliography configuration using dictionary

### DIFF
--- a/src/slides.typ
+++ b/src/slides.typ
@@ -100,12 +100,13 @@
     if self.at("show-bibliography-as-footnote", default: none) != none {
       let args = self.at("show-bibliography-as-footnote", default: none)
       if type(args) == dictionary {
-        let bibliography = args.at("bibliography")
-        args.remove("bibliography")
-        magic.show-bibliography-as-footnote.with(
-          ..args,
+        let bibliography = args.at("bibliography", default: none)
+        let numbering = args.at("numbering", default: "[1]")
+        magic.bibliography-as-footnote(
           bibliography,
           body,
+          numbering: numbering,
+          self: self,
         )
       } else {
         // args is a bibliography like `bibliography(title: none, "ref.bib")`


### PR DESCRIPTION
I have been experimenting with custom numbering for my bibliography. However, using a dictionary in config-common, as explained [here](https://touying-typ.github.io/docs/reference/configs/config-common#show-bibliography-as-footnote) resulted in a compile error. These modifications in `slides.typ` fix the issue. I am new to typst so maybe I am unaware of a better way to do it using `..args` or `.with()`.

Also, I did not find an efficient way to reflect this in `tests/features/bibliography`, I am open to suggestions regarding this. It seems that using `#show: touying-set-config.with(config-common()` with bibliography has no effect on the setting.